### PR TITLE
Feature(#33): 게시물 내용을 담는 `UiState` 생성 및 `repository` 생성

### DIFF
--- a/android/app/src/androidTest/java/com/boostcampwm2023/snappoint/MediaRepositoryTest.kt
+++ b/android/app/src/androidTest/java/com/boostcampwm2023/snappoint/MediaRepositoryTest.kt
@@ -1,0 +1,12 @@
+package com.boostcampwm2023.snappoint
+
+import org.junit.Test
+
+class MediaRepositoryTest {
+
+    @Test
+    fun 미디어_파일을_성공적으로_가져온_경우(){
+
+    }
+
+}

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/SnapPointApi.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/SnapPointApi.kt
@@ -1,0 +1,4 @@
+package com.boostcampwm2023.snappoint.data.remote
+
+interface SnapPointApi {
+}

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/repository/MediaRepository.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/repository/MediaRepository.kt
@@ -1,0 +1,7 @@
+package com.boostcampwm2023.snappoint.data.repository
+
+import kotlinx.coroutines.flow.Flow
+
+interface MediaRepository {
+    fun getImage(uri: String): Flow<ByteArray>
+}

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/repository/MediaRepositoryImpl.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/repository/MediaRepositoryImpl.kt
@@ -1,0 +1,18 @@
+package com.boostcampwm2023.snappoint.data.repository
+
+import com.boostcampwm2023.snappoint.data.remote.SnapPointApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class MediaRepositoryImpl @Inject constructor(
+    private val snapPointApi: SnapPointApi,
+): MediaRepository {
+    override fun getImage(uri: String): Flow<ByteArray> {
+        return flowOf(true)
+            .map{
+            byteArrayOf()
+        }
+    }
+}

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/di/RemoteModule.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/di/RemoteModule.kt
@@ -1,0 +1,29 @@
+package com.boostcampwm2023.snappoint.di
+
+import com.boostcampwm2023.snappoint.data.remote.SnapPointApi
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+
+@Module
+@InstallIn(SingletonComponent::class)
+object RemoteModule {
+
+    @Provides
+    @Singleton
+    fun provideSnapPointApi(): SnapPointApi{
+        return Retrofit.Builder()
+            .baseUrl("asd")
+            .addConverterFactory(Json.asConverterFactory("application/json".toMediaType()))
+            .build()
+            .create(SnapPointApi::class.java)
+    }
+
+}

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/di/RepositoryModule.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/di/RepositoryModule.kt
@@ -1,5 +1,8 @@
 package com.boostcampwm2023.snappoint.di
 
+import com.boostcampwm2023.snappoint.data.repository.MediaRepository
+import com.boostcampwm2023.snappoint.data.repository.MediaRepositoryImpl
+import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
@@ -7,7 +10,14 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-class RepositoryModule {
+object RepositoryModule {
 
-    
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class RepositoryImplModule{
+
+    @Binds
+    abstract fun bindMediaRepository(impl: MediaRepositoryImpl): MediaRepository
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/CreatePostUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/CreatePostUiState.kt
@@ -1,0 +1,16 @@
+package com.boostcampwm2023.snappoint.presentation
+
+data class CreatePostUiState(
+    val postBlocks: List<PostBlock> = emptyList(),
+)
+
+sealed class PostBlock(open val content: String) {
+    data class STRING(override val content: String) : PostBlock(content)
+    data class IMAGE(override val content: String, val position: Position) : PostBlock(content)
+    data class VIDEO(override val content: String, val position: Position) : PostBlock(content)
+}
+
+data class Position(
+    val latitude: Long,
+    val longitude: Long
+)

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/CreatePostUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/CreatePostUiState.kt
@@ -11,6 +11,6 @@ sealed class PostBlock(open val content: String) {
 }
 
 data class Position(
-    val latitude: Long,
-    val longitude: Long
+    val latitude: Double,
+    val longitude: Double
 )


### PR DESCRIPTION
## 작업 개요

- [x] 게시물 내용 UiState 생성
- [x] repository 생성 및 hilt를 통한 의존성 주입 작성 

## 작업 사항

글을 작성할 때 생성하는 블록들의 배열을 UiState 내부에 선언했습니다.
repository를 통해 image에 uri에 대한 값을 요청하는 api를 선언했습니다.

## 고민한 점들

@Provides와 @Binds의 차이를 제대로 이해하지 못해 고민을 많이 했습니다.
프로젝트에서 가지고 있는 클래스나 인터페이스이기 때문에 Binds 키워드를 통해 의존성 주입을 할 수 있도록 구현했습니다.