### PR TITLE
Feature(#9): 게시물 작성 화면 UI 구현

### DIFF
--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostFragment.kt
@@ -1,0 +1,23 @@
+package com.boostcampwm2023.snappoint.presentation.createpost
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.boostcampwm2023.snappoint.R
+import com.boostcampwm2023.snappoint.databinding.FragmentCreatePostBinding
+import com.boostcampwm2023.snappoint.presentation.base.BaseFragment
+
+class CreatePostFragment : BaseFragment<FragmentCreatePostBinding>(R.layout.fragment_create_post) {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_create_post, container, false)
+    }
+}

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostFragment.kt
@@ -1,23 +1,9 @@
 package com.boostcampwm2023.snappoint.presentation.createpost
 
-import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
 import com.boostcampwm2023.snappoint.R
 import com.boostcampwm2023.snappoint.databinding.FragmentCreatePostBinding
 import com.boostcampwm2023.snappoint.presentation.base.BaseFragment
 
 class CreatePostFragment : BaseFragment<FragmentCreatePostBinding>(R.layout.fragment_create_post) {
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-    }
-
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        return inflater.inflate(R.layout.fragment_create_post, container, false)
-    }
 }

--- a/android/app/src/main/res/drawable/icon_arrow_back.xml
+++ b/android/app/src/main/res/drawable/icon_arrow_back.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M17.77,3.77l-1.77,-1.77l-10,10l10,10l1.77,-1.77l-8.23,-8.23z"/>
+    
+</vector>

--- a/android/app/src/main/res/drawable/icon_check.xml
+++ b/android/app/src/main/res/drawable/icon_check.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z"/>
+    
+</vector>

--- a/android/app/src/main/res/drawable/icon_photo_block.xml
+++ b/android/app/src/main/res/drawable/icon_photo_block.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M19,5v14L5,19L5,5h14m0,-2L5,3c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2L21,5c0,-1.1 -0.9,-2 -2,-2zM14.14,11.86l-3,3.87L9,13.14 6,17h12l-3.86,-5.14z"/>
+    
+</vector>

--- a/android/app/src/main/res/drawable/icon_text_block.xml
+++ b/android/app/src/main/res/drawable/icon_text_block.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M2.5,4v3h5v12h3V7h5V4H2.5zM21.5,9h-9v3h3v7h3v-7h3V9z"/>
+    
+</vector>

--- a/android/app/src/main/res/drawable/icon_video_block.xml
+++ b/android/app/src/main/res/drawable/icon_video_block.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M4,6L2,6v14c0,1.1 0.9,2 2,2h14v-2L4,20L4,6zM20,2L8,2c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L22,4c0,-1.1 -0.9,-2 -2,-2zM20,16L8,16L8,4h12v12zM12,5.5v9l6,-4.5z"/>
+    
+</vector>

--- a/android/app/src/main/res/layout/fragment_create_post.xml
+++ b/android/app/src/main/res/layout/fragment_create_post.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/surfaceContainerLow"
+        tools:context=".presentation.createpost.CreatePostFragment">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/tb"
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent"
+            android:background="@color/surfaceColor"
+            app:title="@string/create_post_fragment_appbar_title"
+            app:titleCentered="true"
+            app:layout_constraintTop_toTopOf="parent"
+            android:elevation="2dp" />
+
+        <ImageButton
+            android:id="@+id/btn_back"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/icon_arrow_back"
+            android:background="?attr/actionBarItemBackground"
+            android:padding="16dp"
+            android:layout_marginStart="4dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="@id/tb"
+            android:elevation="2dp"/>
+
+        <ImageButton
+            android:id="@+id/btn_check"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/icon_check"
+            android:background="?attr/actionBarItemBackground"
+            android:padding="16dp"
+            android:layout_marginEnd="4dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="@id/tb"
+            android:elevation="2dp"/>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/til_title"
+            style="@style/Widget.Material3.TextInputLayout.FilledBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/surfaceColor"
+            app:layout_constraintTop_toBottomOf="@id/tb"
+            android:paddingTop="4dp"
+            android:elevation="2dp"
+            android:hint="@string/create_post_fragment_til_title_hint">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:background="@color/surfaceContainerHighest"/>
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toBottomOf="@id/til_title"
+            app:layout_constraintBottom_toBottomOf="@id/btn_insert_text_block"
+            android:background="@color/surfaceColor"
+            android:elevation="2dp"/>
+
+        <ImageButton
+            android:id="@+id/btn_insert_text_block"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/til_title"
+            app:layout_constraintStart_toStartOf="parent"
+            android:src="@drawable/icon_text_block"
+            android:background="?attr/actionBarItemBackground"
+            android:padding="16dp"
+            android:layout_marginStart="8dp"
+            android:elevation="2dp"/>
+
+        <ImageButton
+            android:id="@+id/btn_insert_image_block"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/til_title"
+            app:layout_constraintStart_toEndOf="@id/btn_insert_text_block"
+            android:src="@drawable/icon_photo_block"
+            android:background="?attr/actionBarItemBackground"
+            android:padding="16dp"
+            android:layout_marginStart="8dp"
+            android:elevation="2dp"/>
+
+        <ImageButton
+            android:id="@+id/btn_insert_video_block"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/til_title"
+            app:layout_constraintStart_toEndOf="@id/btn_insert_image_block"
+            android:src="@drawable/icon_video_block"
+            android:background="?attr/actionBarItemBackground"
+            android:padding="16dp"
+            android:layout_marginStart="8dp"
+            android:elevation="2dp"/>
+        
+        <androidx.core.widget.NestedScrollView
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toBottomOf="@id/btn_insert_text_block"
+            app:layout_constraintBottom_toBottomOf="parent"
+            android:padding="20dp">
+            
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rcv_input_block"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+        </androidx.core.widget.NestedScrollView>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -2,4 +2,10 @@
 <resources>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="primaryColor">#3E6A00</color>
+    <color name="secondaryColor">#576249</color>
+    <color name="surfaceColor">#FAFAF2</color>
+    <color name="onSurfaceColor">#1B1C18</color>
+    <color name="surfaceContainerHighest">#E3E3DB</color>
+    <color name="surfaceContainerLow">#F5F4EC</color>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,7 @@
 <resources>
     <string name="app_name">SnapPoint</string>
+    <!-- TODO: Remove or change this placeholder text -->
+    <string name="hello_blank_fragment">Hello blank fragment</string>
+    <string name="create_post_fragment_appbar_title">게시글 작성하기</string>
+    <string name="create_post_fragment_til_title_hint">제목</string>
 </resources>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -2,7 +2,13 @@
     <!-- Base application theme. -->
     <style name="Base.Theme.SnapPoint" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Customize your light theme here. -->
-        <!-- <item name="colorPrimary">@color/my_light_primary</item> -->
+        <item name="colorPrimary">@color/primaryColor</item>
+        <item name="colorSecondary">@color/secondaryColor</item>
+
+        <item name="colorOnSurface">@color/onSurfaceColor</item>
+
+        <item name="colorSurfaceContainerHighest">@color/surfaceContainerHighest</item>
+        <item name="colorSurfaceContainerLow">@color/surfaceContainerLow</item>
     </style>
 
     <style name="Theme.SnapPoint" parent="Base.Theme.SnapPoint" />

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.3.0-alpha07"
+agp = "8.3.0-alpha12"
 kotlin = "1.9.0"
 core-ktx = "1.12.0"
 junit = "4.13.2"

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Nov 07 22:27:58 KST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-rc-2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## 작업 개요
- [x] 게시물 작성 화면인 `CreatePostFragment` 생성
- [x] `CreatePostFragment` UI Layout XML 작성

## 작업 사항
- `CreatePostFragment`를 `BaseFragment`를 상속받도록 구현하였습니다.
- 해당 `Fragment`의 XML 파일을 생성하고, UI 레이아웃을 작성하였습니다.

## 스크린샷
<image src=https://github.com/boostcampwm2023/and01-SnapPoint/assets/85796984/84619438-9cca-47b9-8e6a-5d97f30aa12a width=270 height=600>