### PR TITLE
Feature(#33): 네트워크 요청 API 작성

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -90,4 +90,11 @@ dependencies {
     //mockk
     testImplementation(libs.mockk)
 
+    //mockwebserver
+    testImplementation(libs.mockwebserver)
+    androidTestImplementation(libs.mockwebserver)
+
+    //kotlinx-coroutines-test
+    testImplementation(libs.kotlinx.coroutines.test)
+
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/SnapPointApi.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/SnapPointApi.kt
@@ -1,4 +1,15 @@
 package com.boostcampwm2023.snappoint.data.remote
 
+import retrofit2.http.Field
+import retrofit2.http.FormUrlEncoded
+import retrofit2.http.GET
+import retrofit2.http.Query
+
 interface SnapPointApi {
+
+    @GET("image")
+    suspend fun getImage(
+       @Query ("uri") uri: String,
+    ): String
+
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/SnapPointApi.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/SnapPointApi.kt
@@ -1,7 +1,7 @@
 package com.boostcampwm2023.snappoint.data.remote
 
-import retrofit2.http.Field
-import retrofit2.http.FormUrlEncoded
+import com.boostcampwm2023.snappoint.data.remote.model.response.ImageResponse
+import com.boostcampwm2023.snappoint.data.remote.model.response.ImageUriResponse
 import retrofit2.http.GET
 import retrofit2.http.Query
 
@@ -10,6 +10,11 @@ interface SnapPointApi {
     @GET("image")
     suspend fun getImage(
        @Query ("uri") uri: String,
-    ): String
+    ): ImageResponse
+
+    @GET("image_uri")
+    suspend fun getImageUri(
+        @Query ("image") image: String,
+    ): ImageUriResponse
 
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/model/response/ImageResponse.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/model/response/ImageResponse.kt
@@ -1,0 +1,8 @@
+package com.boostcampwm2023.snappoint.data.remote.model.response
+
+import kotlinx.serialization.SerialName
+
+data class ImageResponse(
+    @SerialName("image")
+    val image: String,
+)

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/model/response/ImageResponse.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/model/response/ImageResponse.kt
@@ -1,7 +1,9 @@
 package com.boostcampwm2023.snappoint.data.remote.model.response
 
 import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class ImageResponse(
     @SerialName("image")
     val image: String,

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/model/response/ImageUriResponse.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/model/response/ImageUriResponse.kt
@@ -1,7 +1,9 @@
 package com.boostcampwm2023.snappoint.data.remote.model.response
 
 import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class ImageUriResponse(
     @SerialName("uri")
     val uri: String,

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/model/response/ImageUriResponse.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/model/response/ImageUriResponse.kt
@@ -1,0 +1,8 @@
+package com.boostcampwm2023.snappoint.data.remote.model.response
+
+import kotlinx.serialization.SerialName
+
+data class ImageUriResponse(
+    @SerialName("uri")
+    val uri: String,
+)

--- a/android/app/src/test/java/com/boostcampwm2023/snappoint/MediaRepositoryTest.kt
+++ b/android/app/src/test/java/com/boostcampwm2023/snappoint/MediaRepositoryTest.kt
@@ -1,6 +1,59 @@
 package com.boostcampwm2023.snappoint
 
+import androidx.test.runner.AndroidJUnit4
+import com.boostcampwm2023.snappoint.data.remote.SnapPointApi
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Retrofit
+
+
 class MediaRepositoryTest {
 
+    private lateinit var server: MockWebServer
+    private lateinit var snapPointApi: SnapPointApi
+    private lateinit var retrofit: Retrofit
+
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+
+        retrofit = Retrofit.Builder()
+            .baseUrl(server.url("/"))
+            .addConverterFactory(Json.asConverterFactory("application/json".toMediaType()))
+            .build()
+
+        snapPointApi = retrofit.create(SnapPointApi::class.java)
+
+    }
+
+    @After
+    fun tearDown(){
+        server.shutdown()
+    }
+
+    @Test
+    fun getImageTest() = runTest {
+        val response = """
+            "image"
+        """.trimIndent()
+
+        server.enqueue(MockResponse().setBody(response))
+
+        val imageByteArray = snapPointApi.getImage(
+            uri = "http://asdf.com"
+        )
+
+        println(imageByteArray)
+
+    }
 
 }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -19,6 +19,8 @@ room_version = "2.6.0"
 mockk_version = "1.13.8"
 exifinterface = "1.3.6"
 rules = "1.5.0"
+mockwebserver = "4.12.0"
+kotlinx-coroutines-test = "1.6.4"
 
 [libraries]
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
@@ -47,6 +49,8 @@ room-ktx = {group = "androidx.room", name = "room-ktx", version.ref = "room_vers
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk_version"}
 androidx-exifinterface = { group = "androidx.exifinterface", name = "exifinterface", version.ref = "exifinterface" }
 androidx-rules = { module = "androidx.test:rules", version.ref = "rules" }
+mockwebserver = {group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "mockwebserver"}
+kotlinx-coroutines-test = {group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines-test"}
 
 
 


### PR DESCRIPTION
## 작업 개요
- [x] api interface 작성
- [x] mockwebserver를 이용한 테스트코드 작성 

## 작업 사항

현재는 서버의 api 명세가 나오지 않아 임의로 작성한 상태입니다.
mockwebserver를 이용해 서버의 응답 값을 임의로 추가해 api 자체에 대한 unitTest만 작성한 상태입니다.
다른 요구사항을 구현할 때, repository에 대한 test를 진행할 예정이고, 이 때 작성한 mockserver를 이용할 예정입니다.

## 고민한 점들(필수 X)

명세가 나오지 않은 상태에서 값들을 예상해 테스트코드를 작성하는 것이 자기만족에 그칠 것 같은 생각이 들었습니다.
실제로 사용되는 테스트코드들의 예시를 더 보고 보완해야 할 것 같습니다.
