### PR TITLE
Setting(#77) Prisma Client 설정 및 NCP DB와 연결

### DIFF
--- a/backend/.prettierrc
+++ b/backend/.prettierrc
@@ -1,4 +1,8 @@
 {
   "singleQuote": true,
-  "trailingComma": "all"
+  "semi": true,
+  "useTabs": false,
+  "trailingComma": "all",
+  "printWidth": 120,
+  "tabWidth": 2
 }

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -4,6 +4,7 @@
 datasource db {
   provider = "mysql"
   url      = env("DATABASE_URL")
+  shadowDatabaseUrl = env("SHADOW_DATABASE_URL")
 }
 
 generator client {

--- a/backend/src/app.controller.spec.ts
+++ b/backend/src/app.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { PrismaService } from './prisma.service';
 
 describe('AppController', () => {
   let appController: AppController;
@@ -8,7 +9,7 @@ describe('AppController', () => {
   beforeEach(async () => {
     const app: TestingModule = await Test.createTestingModule({
       controllers: [AppController],
-      providers: [AppService],
+      providers: [AppService, PrismaService],
     }).compile();
 
     appController = app.get<AppController>(AppController);

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,5 +1,6 @@
-import { Controller, Get } from '@nestjs/common';
+import { Body, Controller, Get, Post } from '@nestjs/common';
 import { AppService } from './app.service';
+import { User as UserModel } from '@prisma/client';
 
 @Controller()
 export class AppController {
@@ -8,5 +9,15 @@ export class AppController {
   @Get()
   getHello(): string {
     return this.appService.getHello();
+  }
+
+  @Get('/users')
+  async getUsers(): Promise<UserModel[]> {
+    return this.appService.getUsers();
+  }
+
+  @Post('/users')
+  async createUser(@Body() userData: { email: string; password: string; nickname: string }): Promise<UserModel> {
+    return this.appService.createUser(userData);
   }
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { PrismaService } from './prisma.service';
 
 @Module({
   imports: [],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [AppService, PrismaService],
 })
 export class AppModule {}

--- a/backend/src/app.service.ts
+++ b/backend/src/app.service.ts
@@ -1,8 +1,20 @@
 import { Injectable } from '@nestjs/common';
+import { PrismaService } from './prisma.service';
+import { Prisma, User } from '@prisma/client';
 
 @Injectable()
 export class AppService {
+  constructor(private prisma: PrismaService) {}
+
   getHello(): string {
     return 'Hello World!';
+  }
+
+  async getUsers(): Promise<User[] | null> {
+    return this.prisma.user.findMany();
+  }
+
+  async createUser(data: Prisma.UserCreateInput): Promise<User> {
+    return await this.prisma.user.create({ data });
   }
 }

--- a/backend/src/prisma.service.ts
+++ b/backend/src/prisma.service.ts
@@ -1,0 +1,9 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService extends PrismaClient implements OnModuleInit {
+  async onModuleInit() {
+    await this.$connect();
+  }
+}


### PR DESCRIPTION
## 작업 개요
- Prisma Client 설정하고, 테스트를 위해 User 생성 및 조회 코드 작성
- NCP 클라우드 연동 위해 Shadow DB 수동 설정 및 연결

## 작업 사항
- Prisma Client 설정하고, 테스트를 위해 User 생성 및 조회 코드 작성
- NCP 클라우드 연동 위해 Shadow DB 수동 설정 및 연결

## 고민한 점들(필수 X)
- Local DB로 테스트 할 떄는 잘 됬지만, NCP MySQL와 연동 시 `P3014` 에러가 발생했습닌다.
- 찾아보니 `Prisma`는 고가용성과 백업을 위해 따로 `Shadow DB` 를 만들다는 것을 알았고, 이 권한이 없어 발생한 문제였습니다.
- 그래서 `MySQL`에서 권한 부여하려고 했으나, 클라우드 완전 관리형 DB여서 DB 생성 권한을 줄 수 없었습니다.
- `NCP Reference`를 참고해, `Console`에서 DB를 설정할 수 있다는 것을 알았고 수동으로 config를 설정해 해결했습니다.

**References**
* https://www.prisma.io/docs/concepts/components/prisma-migrate/shadow-database
* https://guide.ncloud-docs.com/docs/database-database-5-2

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->