### PR TITLE
Feature(#37): `RecyclerView` itemView의 Attach 여부에 따라 TextWatcher 관리

### DIFF
--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/BlockItemViewHolder.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/BlockItemViewHolder.kt
@@ -12,8 +12,8 @@ class BlockItemViewHolder(
 
     private val textWatcher = EditTextWatcher(listener)
 
-    fun bind(s: String, position: Int) {
-        binding.tilText.editText?.setText(s)
+    fun bind(text: String, position: Int) {
+        binding.tilText.editText?.setText(text)
         textWatcher.updatePosition(position)
     }
 
@@ -42,7 +42,7 @@ class EditTextWatcher(private val listener: (Int, String) -> Unit) : TextWatcher
 
     }
 
-    override fun afterTextChanged(s: Editable?) {
-        listener(position, s.toString())
+    override fun afterTextChanged(changedText: Editable?) {
+        listener(position, changedText.toString())
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/BlockItemViewHolder.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/BlockItemViewHolder.kt
@@ -1,21 +1,48 @@
 package com.boostcampwm2023.snappoint.presentation.createpost
 
-import androidx.core.widget.addTextChangedListener
+import android.text.Editable
+import android.text.TextWatcher
 import androidx.recyclerview.widget.RecyclerView
 import com.boostcampwm2023.snappoint.databinding.ItemTextBlockBinding
 
 class BlockItemViewHolder(
     private val binding: ItemTextBlockBinding,
-    private val listener: (Int, String) -> Unit
+    listener: (Int, String) -> Unit
 ) : RecyclerView.ViewHolder(binding.root) {
 
-    private var position = 0
+    private val textWatcher = EditTextWatcher(listener)
 
     fun bind(s: String, position: Int) {
         binding.tilText.editText?.setText(s)
+        textWatcher.updatePosition(position)
+    }
+
+    fun attachTextWatcherToEditText() {
+        binding.tilText.editText?.addTextChangedListener(textWatcher)
+    }
+
+    fun detachTextWatcherFromEditText() {
+        binding.tilText.editText?.removeTextChangedListener(textWatcher)
+    }
+}
+
+class EditTextWatcher(private val listener: (Int, String) -> Unit) : TextWatcher {
+
+    private var position = 0
+
+    fun updatePosition(position: Int) {
         this.position = position
-        binding.tilText.editText?.addTextChangedListener {
-            listener(position, it.toString())
-        }
+    }
+
+    override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+
+    }
+
+    override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+
+    }
+
+    override fun afterTextChanged(s: Editable?) {
+        listener(position, s.toString())
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostFragment.kt
@@ -3,20 +3,15 @@ package com.boostcampwm2023.snappoint.presentation.createpost
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.lifecycleScope
 import com.boostcampwm2023.snappoint.R
 import com.boostcampwm2023.snappoint.databinding.FragmentCreatePostBinding
 import com.boostcampwm2023.snappoint.presentation.base.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class CreatePostFragment : BaseFragment<FragmentCreatePostBinding>(R.layout.fragment_create_post) {
 
     private val viewModel: CreatePostViewModel by viewModels()
-//    private val listAdapter: CreatePostListAdapter by lazy{
-//        CreatePostListAdapter(viewModel.uiState.value)
-//    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -28,19 +23,10 @@ class CreatePostFragment : BaseFragment<FragmentCreatePostBinding>(R.layout.frag
     fun initBinding() {
         with(binding) {
             vm = viewModel
-//            listAdapter.blocks = viewModel.uiState.value.postBlocks.toMutableList()
         }
     }
 
     private fun collectViewModelData() {
-        lifecycleScope.launch {
-            viewModel.uiState.collect {
-//                if (it.postBlocks.size > listAdapter.blocks.size) {
-//                    listAdapter.blocks = it.postBlocks.toMutableList()
-//                    listAdapter.notifyItemInserted(it.postBlocks.size)
-//                    binding.rcvPostBlock.scrollToPosition(it.postBlocks.size - 1)
-//                }
-            }
-        }
+
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostListAdapter.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostListAdapter.kt
@@ -1,6 +1,5 @@
 package com.boostcampwm2023.snappoint.presentation.createpost
 
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.databinding.BindingAdapter
@@ -33,18 +32,17 @@ class CreatePostListAdapter(
     }
 
     override fun onBindViewHolder(holder: BlockItemViewHolder, position: Int) {
-        Log.d("TAG", "onBindViewHolder: $position")
         holder.bind(blocks[position].content, position)
     }
 
     override fun onViewAttachedToWindow(holder: BlockItemViewHolder) {
         super.onViewAttachedToWindow(holder)
-        Log.d("TAG", "onViewAttachedToWindow: ")
+        holder.attachTextWatcherToEditText()
     }
 
     override fun onViewDetachedFromWindow(holder: BlockItemViewHolder) {
         super.onViewDetachedFromWindow(holder)
-        Log.d("TAG", "onViewDetachedFromWindow: ")
+        holder.detachTextWatcherFromEditText()
     }
 }
 
@@ -53,18 +51,19 @@ fun RecyclerView.bindRecyclerViewAdapter(blocks: List<PostBlock>, listener: (Int
     if (adapter == null) adapter = CreatePostListAdapter(listener)
 
     when {
+        // 아이템 추가
         (adapter as CreatePostListAdapter).getCurrentBlocks().size < blocks.size -> {
             with(adapter as CreatePostListAdapter) {
                 updateBlocks(blocks)
                 notifyItemInserted(blocks.size - 1)
             }
         }
-//
-//        (adapter as CreatePostListAdapter).getCurrentBlocks().size == blocks.size -> {
-//            with(adapter as CreatePostListAdapter) {
-//                updateBlocks(blocks)
-//                notifyItemRangeChanged(0, blocks.size)
-//            }
-//        }
+
+        // content 변경
+        (adapter as CreatePostListAdapter).getCurrentBlocks().size == blocks.size -> {
+            with(adapter as CreatePostListAdapter) {
+                updateBlocks(blocks)
+            }
+        }
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/PostBlockListAdapter.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/PostBlockListAdapter.kt
@@ -1,6 +1,5 @@
 package com.boostcampwm2023.snappoint.presentation.createpost
 
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil


### PR DESCRIPTION
## 작업 개요
- [x] `itemView`가 Attach될 때 Listener를 추가하고, Detach될 때 제거하여 `EditText` 데이터가 유실되는 문제 해결

## 작업 사항
- `itemView`가 화면에서 사라져도 Listener가 살아있어 데이터가 유실된다고 판단
- Listener를 제거하려면 `TextWatcher`의 인스턴스로 제거하는 방법밖에 없는 것 같아, `TextWatcher`를 상속받아 Listener를 실행하는 클래스를 구현하고, 이를 `ViewHolder`에 인스턴스로 생성하여 함께 관리
- Adapter에서 `onViewAttachedToWindow`가 호출될 때 `TextWatcher`도 함께 추가하고, `onViewDetachedFromWindow`가 호출될 때 제거하여 데이터가 유실되는 문제 해결

## 고민한 점들
- 처음에는 `TextWatcher`를 전부 구현하지 않고 필요한 부분만 구현해서 추가해주려고 했는데, `TextWatcher`인스턴스가 없으면 제거를 해줄 수 없는 것 같아 결국 사용하지 않는 부분을 포함하는 `TextWatcher` 구현체를 구현하였다. 
- `ListAdapter`를 사용하면 대부분 해결될 문제인 것 같은데, data class 내에 동일한 객체임을 보여줄 수 있는 `id`같은 unique한 속성이 없어서 `ListAdapter`를 사용하지 못했다. `ListAdapter`를 사용하기 위해 data class에 unique한 속성을 추가해주는 것이 맞는지 모르겠다.