### PR TITLE
Feature(#20): 게시물 작성 이벤트 전달 및 입력값 유효성 검사

### DIFF
--- a/android/app/src/androidTest/java/com/boostcampwm2023/snappoint/CreatePostViewModelTest.kt
+++ b/android/app/src/androidTest/java/com/boostcampwm2023/snappoint/CreatePostViewModelTest.kt
@@ -1,0 +1,29 @@
+package com.boostcampwm2023.snappoint
+
+import com.boostcampwm2023.snappoint.presentation.createpost.CreatePostViewModel
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class CreatePostViewModelTest {
+
+    private lateinit var viewModel: CreatePostViewModel
+
+    @Before
+    fun setUp(){
+        viewModel = CreatePostViewModel()
+    }
+
+    @Test
+    fun isValidContents_Empty_StringBlock_returns_false(){
+
+
+
+    }
+
+    @After
+    fun tearDown(){
+        viewModel.
+    }
+}

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostEvent.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostEvent.kt
@@ -1,0 +1,5 @@
+package com.boostcampwm2023.snappoint.presentation.createpost
+
+sealed class CreatePostEvent {
+    data class ShowMessage(val resId: Int): CreatePostEvent()
+}

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostFragment.kt
@@ -2,13 +2,16 @@ package com.boostcampwm2023.snappoint.presentation.createpost
 
 import android.os.Bundle
 import android.view.View
+import android.widget.Toast
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.boostcampwm2023.snappoint.R
 import com.boostcampwm2023.snappoint.databinding.FragmentCreatePostBinding
 import com.boostcampwm2023.snappoint.presentation.base.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
+import kotlinx.serialization.descriptors.PrimitiveKind
 
 @AndroidEntryPoint
 class CreatePostFragment : BaseFragment<FragmentCreatePostBinding>(R.layout.fragment_create_post) {
@@ -34,13 +37,16 @@ class CreatePostFragment : BaseFragment<FragmentCreatePostBinding>(R.layout.frag
 
     private fun collectViewModelData() {
         lifecycleScope.launch {
-            viewModel.uiState.collect {
-//                if (it.postBlocks.size > listAdapter.blocks.size) {
-//                    listAdapter.blocks = it.postBlocks.toMutableList()
-//                    listAdapter.notifyItemInserted(it.postBlocks.size)
-//                    binding.rcvPostBlock.scrollToPosition(it.postBlocks.size - 1)
-//                }
+            viewModel.event.collect{event ->
+                when(event){
+                    is CreatePostEvent.ShowMessage -> {showToastMessage(event.resId)}
+                }
             }
+
         }
+    }
+
+    private fun showToastMessage(resId: Int) {
+        Toast.makeText(requireContext(), getString(resId), Toast.LENGTH_LONG).show()
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostViewModel.kt
@@ -61,7 +61,18 @@ class CreatePostViewModel @Inject constructor() : ViewModel() {
         Log.d("TAG", "updatePostBlocks: ${_uiState.value.postBlocks[position].content}")
     }
 
-    fun printBlockList() {
-        println(uiState.value.postBlocks)
+    private fun isValidContents(): Boolean {
+        _uiState.value.postBlocks.forEach {
+            when(it){
+                is PostBlock.STRING -> {if(it.content.isEmpty()) return false}
+                is PostBlock.IMAGE -> {if(it.content.isEmpty()) return false}
+                is PostBlock.VIDEO -> {if(it.content.isEmpty()) return false}
+            }
+        }
+        return true
+    }
+
+    fun onCheckButtonClicked() {
+        
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostViewModel.kt
@@ -2,9 +2,14 @@ package com.boostcampwm2023.snappoint.presentation.createpost
 
 import android.util.Log
 import androidx.lifecycle.ViewModel
+import com.boostcampwm2023.snappoint.R
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import javax.inject.Inject
@@ -18,6 +23,13 @@ class CreatePostViewModel @Inject constructor() : ViewModel() {
         }
     ))
     val uiState: StateFlow<CreatePostUiState> = _uiState.asStateFlow()
+
+    private val _event: MutableSharedFlow<CreatePostEvent> = MutableSharedFlow(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+    val event: SharedFlow<CreatePostEvent> = _event.asSharedFlow()
+
 
     fun addTextBlock() {
         _uiState.update {
@@ -73,6 +85,8 @@ class CreatePostViewModel @Inject constructor() : ViewModel() {
     }
 
     fun onCheckButtonClicked() {
-        
+        if(isValidContents().not()){
+            _event.tryEmit(CreatePostEvent.ShowMessage(R.string.create_post_fragment_empty_block))
+        }
     }
 }

--- a/android/app/src/main/res/layout/fragment_create_post.xml
+++ b/android/app/src/main/res/layout/fragment_create_post.xml
@@ -50,7 +50,7 @@
             app:layout_constraintBottom_toBottomOf="@id/tb"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            android:onClick="@{() -> vm.printBlockList()}"/>
+            android:onClick="@{() -> vm.onCheckButtonClicked()}"/>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/til_title"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
     <string name="create_post_fragment_appbar_title">게시글 작성하기</string>
     <string name="create_post_fragment_til_title_hint">제목</string>
     <string name="item_text_block_til_hint">본문 내용</string>
+    <string name="create_post_fragment_empty_block">비어있는 블록이 존재합니다.</string>
 </resources>


### PR DESCRIPTION
## 작업 개요

- [ ] 게시글 생성 이벤트를 viewModel로 전달하고, 유효성 검사
- [ ] 유효하지 않은 내용 메시지 이벤트 전달 및 표시

## 작업 사항

게시글에 있는 block들에 대해 content의 값을 기준으로 유효성 검사를 진행하게 구현한 상태입니다.

유효하지 않은 부분에 대해서는 sharedFlow를 통해 이벤트를 UI에 전달할 수 있도록 구현했습니다.
현재는 메시지를 Toast의 형태로 전달했고, 메시지 표시 방법에 대한 논의가 필요할 것 같습니다.