### PR TITLE
Feature(#29): 게시물 블록 삭제 기능

### DIFF
--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/BlockItemViewHolder.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/BlockItemViewHolder.kt
@@ -23,11 +23,13 @@ sealed class BlockItemViewHolder(
 
     class TextBlockViewHolder(
         private val binding: ItemTextBlockBinding,
-        listener: (Int, String) -> Unit
+        listener: (Int, String) -> Unit,
+        private val onDeleteButtonClicked: (Int) -> Unit
     ) : BlockItemViewHolder(binding, listener) {
 
         fun bind(content: String, position: Int) {
             binding.tilText.editText?.setText(content)
+            binding.onDeleteButtonClick = { onDeleteButtonClicked(position) }
             textWatcher.updatePosition(position)
         }
 
@@ -42,11 +44,13 @@ sealed class BlockItemViewHolder(
 
     class ImageBlockViewHolder(
         private val binding: ItemImageBlockBinding,
-        listener: (Int, String) -> Unit
+        listener: (Int, String) -> Unit,
+        private val onDeleteButtonClicked: (Int) -> Unit
     ) : BlockItemViewHolder(binding, listener) {
 
         fun bind(content: String, uri: Uri, position: Int) {
             binding.tilDescription.editText?.setText(content)
+            binding.onDeleteButtonClick = { onDeleteButtonClicked(position) }
             binding.uri = uri
             textWatcher.updatePosition(position)
         }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostListAdapter.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostListAdapter.kt
@@ -8,7 +8,8 @@ import com.boostcampwm2023.snappoint.databinding.ItemImageBlockBinding
 import com.boostcampwm2023.snappoint.databinding.ItemTextBlockBinding
 
 class CreatePostListAdapter(
-    private val listener: (Int, String) -> Unit
+    private val listener: (Int, String) -> Unit,
+    private val onDeleteButtonClicked: (Int) -> Unit
 ) : RecyclerView.Adapter<BlockItemViewHolder>() {
 
     private var blocks: MutableList<PostBlock> = mutableListOf()
@@ -17,6 +18,12 @@ class CreatePostListAdapter(
 
     fun updateBlocks(newBlocks: List<PostBlock>) {
         blocks = newBlocks.toMutableList()
+    }
+
+    private fun deleteBlocks(position: Int) {
+        blocks.removeAt(position)
+        notifyItemRemoved(position)
+        notifyItemRangeChanged(position, blocks.size - position)
     }
 
     override fun getItemViewType(position: Int): Int {
@@ -35,7 +42,10 @@ class CreatePostListAdapter(
                 return BlockItemViewHolder.ImageBlockViewHolder(
                     ItemImageBlockBinding.inflate(inflater, parent, false),
                     listener
-                )
+                ) { index ->
+                    onDeleteButtonClicked(index)
+                    deleteBlocks(index)
+                }
             }
 
             ViewType.VIDEO.ordinal -> {
@@ -45,7 +55,10 @@ class CreatePostListAdapter(
         return BlockItemViewHolder.TextBlockViewHolder(
             ItemTextBlockBinding.inflate(inflater, parent, false),
             listener
-        )
+        ) { index ->
+            onDeleteButtonClicked(index)
+            deleteBlocks(index)
+        }
     }
 
     override fun getItemCount(): Int {
@@ -70,9 +83,9 @@ class CreatePostListAdapter(
     }
 }
 
-@BindingAdapter("blocks", "listener")
-fun RecyclerView.bindRecyclerViewAdapter(blocks: List<PostBlock>, listener: (Int, String) -> Unit) {
-    if (adapter == null) adapter = CreatePostListAdapter(listener)
+@BindingAdapter("blocks", "listener", "onDeleteButtonClick")
+fun RecyclerView.bindRecyclerViewAdapter(blocks: List<PostBlock>, listener: (Int, String) -> Unit, onDeleteButtonClicked: (Int) -> Unit) {
+    if (adapter == null) adapter = CreatePostListAdapter(listener, onDeleteButtonClicked)
 
     when {
         // 아이템 추가

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostUiState.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 data class CreatePostUiState(
     val postBlocks: List<PostBlock> = mutableListOf(),
     val onTextChanged: (position: Int, content: String) -> Unit,
+    val onDeleteButtonClicked: (position: Int) -> Unit,
 )
 
 sealed class PostBlock(open val content: String) {

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostViewModel.kt
@@ -31,6 +31,9 @@ class CreatePostViewModel @Inject constructor(
     private val _uiState: MutableStateFlow<CreatePostUiState> = MutableStateFlow(CreatePostUiState(
         onTextChanged = { position, content ->
             updatePostBlocks(position, content)
+        },
+        onDeleteButtonClicked = { position ->
+            deletePostBlock(position)
         }
     ))
     val uiState: StateFlow<CreatePostUiState> = _uiState.asStateFlow()
@@ -62,6 +65,16 @@ class CreatePostViewModel @Inject constructor(
 
     fun addVideoBlock() {
         TODO()
+    }
+
+    private fun deletePostBlock(position: Int) {
+        _uiState.update {
+            it.copy(
+                postBlocks = it.postBlocks.filterIndexed { index, _ ->
+                    index != position
+                }
+            )
+        }
     }
 
     private fun updatePostBlocks(position: Int, content: String) {

--- a/android/app/src/main/res/layout/fragment_create_post.xml
+++ b/android/app/src/main/res/layout/fragment_create_post.xml
@@ -126,6 +126,7 @@
             android:padding="20dp"
             blocks="@{vm.uiState.postBlocks}"
             listener="@{vm.uiState.onTextChanged}"
+            onDeleteButtonClick="@{vm.uiState.onDeleteButtonClicked}"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             tools:listitem="@layout/item_text_block"/>
 

--- a/android/app/src/main/res/layout/item_image_block.xml
+++ b/android/app/src/main/res/layout/item_image_block.xml
@@ -4,6 +4,11 @@
 
     <data>
 
+        <import type="kotlin.jvm.functions.Function0"/>
+        <import type="kotlin.Unit"/>
+        <variable
+            name="onDeleteButtonClick"
+            type="Function0&lt;Unit>" />
         <variable
             name="uri"
             type="android.net.Uri" />
@@ -36,7 +41,8 @@
             android:background="?attr/actionBarItemBackground"
             android:padding="16dp"
             android:layout_marginVertical="8dp"
-            app:tint="@color/errorContainer" />
+            app:tint="@color/errorContainer"
+            android:onClick="@{() -> onDeleteButtonClick.invoke()}"/>
 
         <ImageButton
             android:id="@+id/btn_edit_block"

--- a/android/app/src/main/res/layout/item_text_block.xml
+++ b/android/app/src/main/res/layout/item_text_block.xml
@@ -4,6 +4,12 @@
 
     <data>
 
+        <import type="kotlin.jvm.functions.Function0"/>
+        <import type="kotlin.Unit"/>
+        <variable
+            name="onDeleteButtonClick"
+            type="Function0&lt;Unit>" />
+
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -32,7 +38,8 @@
             android:background="?attr/actionBarItemBackground"
             android:padding="16dp"
             android:layout_marginVertical="8dp"
-            app:tint="@color/errorContainer" />
+            app:tint="@color/errorContainer"
+            android:onClick="@{() -> onDeleteButtonClick.invoke()}"/>
 
         <ImageButton
             android:id="@+id/btn_edit_block"


### PR DESCRIPTION
## 작업 개요
- [x] 각 블록의 휴지통 버튼을 클릭하면 데이터에서 해당 블록을 삭제한다.
- [x] 데이터의 변경 사항을 화면에 반영한다.

## 작업 사항
- 각 `PostBlock`의 휴지통 버튼을 클릭하면, 해당 `PostBlock`이 `UiState`의 `postBlocks`에서 제거된다.
- RecyclerView Adapter에서 관리하는 리스트에서도 해당 아이템이 제거되며, `notifyItemRemoved()`와 `notifyItemRangeChanged()`메소드를 통해 변경 사항이 반영되고 화면이 업데이트된다.

## 고민한 점들
- 처음에는 아이템 추가나 변경과 함께 바인딩 어댑터에서 구현하려 했는데, 그러면 어느 인덱스의 아이템이 제거된 것인지 알려주기가 번거로웠다. 그래서 그냥 RecyclerView.Adapter에서 아이템 삭제 시 필요한 동작들을 구현하고, ViewHolder에 해당 동작들을 람다 함수로 넘겨서 휴지통 버튼이 클릭되면 해당 동작들이 실행되도록 구현하였다.
