### PR TITLE
Feature(#31): 게시물 블록 위치 변경 기능 구현

### DIFF
--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/BlockItemViewHolder.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/BlockItemViewHolder.kt
@@ -27,13 +27,15 @@ sealed class BlockItemViewHolder(
         private val binding: ItemTextBlockBinding,
         listener: (Int, String) -> Unit,
         private val onEditButtonClicked: (Int) -> Unit,
-        private val onDeleteButtonClicked: (Int) -> Unit
+        private val onCheckButtonClicked: (Int) -> Unit,
+        private val onDeleteButtonClicked: (Int) -> Unit,
     ) : BlockItemViewHolder(binding, listener) {
 
         fun bind(block: PostBlockState.STRING, position: Int) {
             binding.tilText.editText?.setText(block.content)
             binding.onDeleteButtonClick = { onDeleteButtonClicked(position) }
             binding.btnEditBlock.setOnClickListener { onEditButtonClicked(position) }
+            binding.btnEditComplete.setOnClickListener { onCheckButtonClicked(position) }
             binding.editMode = block.isEditMode
             textWatcher.updatePosition(position)
         }
@@ -51,13 +53,15 @@ sealed class BlockItemViewHolder(
         private val binding: ItemImageBlockBinding,
         listener: (Int, String) -> Unit,
         private val onEditButtonClicked: (Int) -> Unit,
-        private val onDeleteButtonClicked: (Int) -> Unit
+        private val onCheckButtonClicked: (Int) -> Unit,
+        private val onDeleteButtonClicked: (Int) -> Unit,
     ) : BlockItemViewHolder(binding, listener) {
 
         fun bind(block: PostBlockState.IMAGE, position: Int) {
             binding.tilDescription.editText?.setText(block.content)
             binding.onDeleteButtonClick = { onDeleteButtonClicked(position) }
             binding.btnEditBlock.setOnClickListener { onEditButtonClicked(position) }
+            binding.btnEditComplete.setOnClickListener { onCheckButtonClicked(position) }
             binding.uri = block.uri
             binding.editMode = block.isEditMode
             textWatcher.updatePosition(position)

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/BlockItemViewHolder.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/BlockItemViewHolder.kt
@@ -28,14 +28,27 @@ sealed class BlockItemViewHolder(
         listener: (Int, String) -> Unit,
         private val onEditButtonClicked: (Int) -> Unit,
         private val onCheckButtonClicked: (Int) -> Unit,
+        private val onUpButtonClicked: (position: Int) -> Unit,
+        private val onDownButtonClicked: (position: Int) -> Unit,
         private val onDeleteButtonClicked: (Int) -> Unit,
     ) : BlockItemViewHolder(binding, listener) {
 
         fun bind(block: PostBlockState.STRING, position: Int) {
             binding.tilText.editText?.setText(block.content)
             binding.onDeleteButtonClick = { onDeleteButtonClicked(position) }
-            binding.btnEditBlock.setOnClickListener { onEditButtonClicked(position) }
+            binding.btnEditBlock.setOnClickListener {
+                itemView.rootView.clearFocus()
+                onEditButtonClicked(position)
+            }
             binding.btnEditComplete.setOnClickListener { onCheckButtonClicked(position) }
+            binding.btnUp.setOnClickListener {
+                itemView.rootView.clearFocus()
+                onUpButtonClicked(position)
+            }
+            binding.btnDown.setOnClickListener {
+                itemView.rootView.clearFocus()
+                onDownButtonClicked(position)
+            }
             binding.editMode = block.isEditMode
             textWatcher.updatePosition(position)
         }
@@ -54,14 +67,27 @@ sealed class BlockItemViewHolder(
         listener: (Int, String) -> Unit,
         private val onEditButtonClicked: (Int) -> Unit,
         private val onCheckButtonClicked: (Int) -> Unit,
+        private val onUpButtonClicked: (position: Int) -> Unit,
+        private val onDownButtonClicked: (position: Int) -> Unit,
         private val onDeleteButtonClicked: (Int) -> Unit,
     ) : BlockItemViewHolder(binding, listener) {
 
         fun bind(block: PostBlockState.IMAGE, position: Int) {
             binding.tilDescription.editText?.setText(block.content)
             binding.onDeleteButtonClick = { onDeleteButtonClicked(position) }
-            binding.btnEditBlock.setOnClickListener { onEditButtonClicked(position) }
+            binding.btnEditBlock.setOnClickListener {
+                itemView.rootView.clearFocus()
+                onEditButtonClicked(position)
+            }
             binding.btnEditComplete.setOnClickListener { onCheckButtonClicked(position) }
+            binding.btnUp.setOnClickListener {
+                itemView.rootView.clearFocus()
+                onUpButtonClicked(position)
+            }
+            binding.btnDown.setOnClickListener {
+                itemView.rootView.clearFocus()
+                onDownButtonClicked(position)
+            }
             binding.uri = block.uri
             binding.editMode = block.isEditMode
             textWatcher.updatePosition(position)

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/BlockItemViewHolder.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/BlockItemViewHolder.kt
@@ -109,7 +109,11 @@ fun ImageView.bindUri(uri: Uri) {
 fun MaterialCardView.isEditMode(editMode: Boolean) {
     val value = TypedValue()
     val width = if (editMode) {
-        context.theme.resolveAttribute(com.google.android.material.R.attr.colorSecondary, value, true)
+        context.theme.resolveAttribute(
+            com.google.android.material.R.attr.colorSecondary,
+            value,
+            true
+        )
         4
     } else {
         context.theme.resolveAttribute(com.google.android.material.R.attr.colorOutline, value, true)

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/BlockItemViewHolder.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/BlockItemViewHolder.kt
@@ -3,6 +3,7 @@ package com.boostcampwm2023.snappoint.presentation.createpost
 import android.net.Uri
 import android.text.Editable
 import android.text.TextWatcher
+import android.util.TypedValue
 import android.widget.ImageView
 import androidx.databinding.BindingAdapter
 import androidx.databinding.ViewDataBinding
@@ -10,6 +11,7 @@ import androidx.recyclerview.widget.RecyclerView
 import coil.load
 import com.boostcampwm2023.snappoint.databinding.ItemImageBlockBinding
 import com.boostcampwm2023.snappoint.databinding.ItemTextBlockBinding
+import com.google.android.material.card.MaterialCardView
 
 sealed class BlockItemViewHolder(
     binding: ViewDataBinding,
@@ -24,12 +26,15 @@ sealed class BlockItemViewHolder(
     class TextBlockViewHolder(
         private val binding: ItemTextBlockBinding,
         listener: (Int, String) -> Unit,
+        private val onEditButtonClicked: (Int) -> Unit,
         private val onDeleteButtonClicked: (Int) -> Unit
     ) : BlockItemViewHolder(binding, listener) {
 
-        fun bind(content: String, position: Int) {
-            binding.tilText.editText?.setText(content)
+        fun bind(block: PostBlockState.STRING, position: Int) {
+            binding.tilText.editText?.setText(block.content)
             binding.onDeleteButtonClick = { onDeleteButtonClicked(position) }
+            binding.btnEditBlock.setOnClickListener { onEditButtonClicked(position) }
+            binding.editMode = block.isEditMode
             textWatcher.updatePosition(position)
         }
 
@@ -45,13 +50,16 @@ sealed class BlockItemViewHolder(
     class ImageBlockViewHolder(
         private val binding: ItemImageBlockBinding,
         listener: (Int, String) -> Unit,
+        private val onEditButtonClicked: (Int) -> Unit,
         private val onDeleteButtonClicked: (Int) -> Unit
     ) : BlockItemViewHolder(binding, listener) {
 
-        fun bind(content: String, uri: Uri, position: Int) {
-            binding.tilDescription.editText?.setText(content)
+        fun bind(block: PostBlockState.IMAGE, position: Int) {
+            binding.tilDescription.editText?.setText(block.content)
             binding.onDeleteButtonClick = { onDeleteButtonClicked(position) }
-            binding.uri = uri
+            binding.btnEditBlock.setOnClickListener { onEditButtonClicked(position) }
+            binding.uri = block.uri
+            binding.editMode = block.isEditMode
             textWatcher.updatePosition(position)
         }
 
@@ -91,4 +99,18 @@ class EditTextWatcher(private val listener: (Int, String) -> Unit) : TextWatcher
 @BindingAdapter("uri")
 fun ImageView.bindUri(uri: Uri) {
     load(uri)
+}
+
+@BindingAdapter("editMode")
+fun MaterialCardView.isEditMode(editMode: Boolean) {
+    val value = TypedValue()
+    val width = if (editMode) {
+        context.theme.resolveAttribute(com.google.android.material.R.attr.colorSecondary, value, true)
+        4
+    } else {
+        context.theme.resolveAttribute(com.google.android.material.R.attr.colorOutline, value, true)
+        1
+    }
+    strokeWidth = width
+    strokeColor = value.data
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostListAdapter.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostListAdapter.kt
@@ -12,6 +12,8 @@ class CreatePostListAdapter(
     private val onDeleteButtonClicked: (Int) -> Unit,
     private val onEditButtonClicked: (Int) -> Unit,
     private val onCheckButtonClicked: (Int) -> Unit,
+    private val onUpButtonClicked: (position: Int) -> Unit,
+    private val onDownButtonClicked: (position: Int) -> Unit,
 ) : RecyclerView.Adapter<BlockItemViewHolder>() {
 
     private var blocks: MutableList<PostBlockState> = mutableListOf()
@@ -28,6 +30,22 @@ class CreatePostListAdapter(
         notifyItemRangeChanged(position, blocks.size - position)
     }
 
+    private fun moveUpBlock(position: Int) {
+        if (position == 0) return
+        val tmp = blocks[position]
+        blocks[position] = blocks[position - 1]
+        blocks[position - 1] = tmp
+        notifyItemRangeChanged(position - 1, 2)
+    }
+
+    private fun moveDownBlock(position: Int) {
+        if (position == blocks.lastIndex) return
+        val tmp = blocks[position]
+        blocks[position] = blocks[position + 1]
+        blocks[position + 1] = tmp
+        notifyItemRangeChanged(position, 2)
+    }
+
     override fun getItemViewType(position: Int): Int {
         return when (blocks[position]) {
             is PostBlockState.STRING -> ViewType.STRING.ordinal
@@ -38,6 +56,18 @@ class CreatePostListAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BlockItemViewHolder {
         val inflater = LayoutInflater.from(parent.context)
+        val onDeleteButtonClicked: (Int) -> Unit = { index ->
+            onDeleteButtonClicked(index)
+            deleteBlocks(index)
+        }
+        val onUpButtonClicked: (Int) -> Unit = { index ->
+            onUpButtonClicked(index)
+            moveUpBlock(index)
+        }
+        val onDownButtonClicked: (Int) -> Unit = { index ->
+            onDownButtonClicked(index)
+            moveDownBlock(index)
+        }
 
         when (viewType) {
             ViewType.IMAGE.ordinal -> {
@@ -46,10 +76,10 @@ class CreatePostListAdapter(
                     listener,
                     onEditButtonClicked,
                     onCheckButtonClicked,
-                ) { index ->
-                    onDeleteButtonClicked(index)
-                    deleteBlocks(index)
-                }
+                    onUpButtonClicked,
+                    onDownButtonClicked,
+                    onDeleteButtonClicked
+                )
             }
 
             ViewType.VIDEO.ordinal -> {
@@ -60,11 +90,11 @@ class CreatePostListAdapter(
             ItemTextBlockBinding.inflate(inflater, parent, false),
             listener,
             onEditButtonClicked,
-            onCheckButtonClicked
-        ) { index ->
-            onDeleteButtonClicked(index)
-            deleteBlocks(index)
-        }
+            onCheckButtonClicked,
+            onUpButtonClicked,
+            onDownButtonClicked,
+            onDeleteButtonClicked
+        )
     }
 
     override fun getItemCount(): Int {
@@ -109,20 +139,26 @@ class CreatePostListAdapter(
     "listener",
     "onDeleteButtonClick",
     "onEditButtonClick",
-    "onCheckButtonClick"
+    "onCheckButtonClick",
+    "onUpButtonClick",
+    "onDownButtonClick"
 )
 fun RecyclerView.bindRecyclerViewAdapter(
     blocks: List<PostBlockState>,
     listener: (Int, String) -> Unit,
     onDeleteButtonClicked: (Int) -> Unit,
     onEditButtonClicked: (Int) -> Unit,
-    onCheckButtonClicked: (Int) -> Unit
+    onCheckButtonClicked: (Int) -> Unit,
+    onUpButtonClicked: (Int) -> Unit,
+    onDownButtonClicked: (Int) -> Unit
 ) {
     if (adapter == null) adapter = CreatePostListAdapter(
         listener,
         onDeleteButtonClicked,
         onEditButtonClicked,
-        onCheckButtonClicked
+        onCheckButtonClicked,
+        onUpButtonClicked,
+        onDownButtonClicked
     )
 
     when {

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostListAdapter.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostListAdapter.kt
@@ -29,7 +29,7 @@ class CreatePostListAdapter(
     }
 
     override fun getItemViewType(position: Int): Int {
-        return when(blocks[position]) {
+        return when (blocks[position]) {
             is PostBlockState.STRING -> ViewType.STRING.ordinal
             is PostBlockState.IMAGE -> ViewType.IMAGE.ordinal
             is PostBlockState.VIDEO -> ViewType.VIDEO.ordinal
@@ -73,8 +73,15 @@ class CreatePostListAdapter(
 
     override fun onBindViewHolder(holder: BlockItemViewHolder, position: Int) {
         when (holder) {
-            is BlockItemViewHolder.TextBlockViewHolder -> holder.bind(blocks[position] as PostBlockState.STRING, position)
-            is BlockItemViewHolder.ImageBlockViewHolder -> holder.bind(blocks[position] as PostBlockState.IMAGE, position)
+            is BlockItemViewHolder.TextBlockViewHolder -> holder.bind(
+                blocks[position] as PostBlockState.STRING,
+                position
+            )
+
+            is BlockItemViewHolder.ImageBlockViewHolder -> holder.bind(
+                blocks[position] as PostBlockState.IMAGE,
+                position
+            )
         }
     }
 
@@ -88,7 +95,7 @@ class CreatePostListAdapter(
         holder.detachTextWatcherFromEditText()
     }
 
-    companion object{
+    companion object {
         enum class ViewType {
             STRING,
             IMAGE,
@@ -97,9 +104,26 @@ class CreatePostListAdapter(
     }
 }
 
-@BindingAdapter("blocks", "listener", "onDeleteButtonClick", "onEditButtonClick", "onCheckButtonClick")
-fun RecyclerView.bindRecyclerViewAdapter(blocks: List<PostBlockState>, listener: (Int, String) -> Unit, onDeleteButtonClicked: (Int) -> Unit, onEditButtonClicked: (Int) -> Unit, onCheckButtonClicked: (Int) -> Unit) {
-    if (adapter == null) adapter = CreatePostListAdapter(listener, onDeleteButtonClicked, onEditButtonClicked, onCheckButtonClicked)
+@BindingAdapter(
+    "blocks",
+    "listener",
+    "onDeleteButtonClick",
+    "onEditButtonClick",
+    "onCheckButtonClick"
+)
+fun RecyclerView.bindRecyclerViewAdapter(
+    blocks: List<PostBlockState>,
+    listener: (Int, String) -> Unit,
+    onDeleteButtonClicked: (Int) -> Unit,
+    onEditButtonClicked: (Int) -> Unit,
+    onCheckButtonClicked: (Int) -> Unit
+) {
+    if (adapter == null) adapter = CreatePostListAdapter(
+        listener,
+        onDeleteButtonClicked,
+        onEditButtonClicked,
+        onCheckButtonClicked
+    )
 
     when {
         // 아이템 추가

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostListAdapter.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostListAdapter.kt
@@ -11,6 +11,7 @@ class CreatePostListAdapter(
     private val listener: (Int, String) -> Unit,
     private val onDeleteButtonClicked: (Int) -> Unit,
     private val onEditButtonClicked: (Int) -> Unit,
+    private val onCheckButtonClicked: (Int) -> Unit,
 ) : RecyclerView.Adapter<BlockItemViewHolder>() {
 
     private var blocks: MutableList<PostBlockState> = mutableListOf()
@@ -43,7 +44,8 @@ class CreatePostListAdapter(
                 return BlockItemViewHolder.ImageBlockViewHolder(
                     ItemImageBlockBinding.inflate(inflater, parent, false),
                     listener,
-                    onEditButtonClicked
+                    onEditButtonClicked,
+                    onCheckButtonClicked,
                 ) { index ->
                     onDeleteButtonClicked(index)
                     deleteBlocks(index)
@@ -57,7 +59,8 @@ class CreatePostListAdapter(
         return BlockItemViewHolder.TextBlockViewHolder(
             ItemTextBlockBinding.inflate(inflater, parent, false),
             listener,
-            onEditButtonClicked
+            onEditButtonClicked,
+            onCheckButtonClicked
         ) { index ->
             onDeleteButtonClicked(index)
             deleteBlocks(index)
@@ -94,9 +97,9 @@ class CreatePostListAdapter(
     }
 }
 
-@BindingAdapter("blocks", "listener", "onDeleteButtonClick", "onEditButtonClick")
-fun RecyclerView.bindRecyclerViewAdapter(blocks: List<PostBlockState>, listener: (Int, String) -> Unit, onDeleteButtonClicked: (Int) -> Unit, onEditButtonClicked: (Int) -> Unit) {
-    if (adapter == null) adapter = CreatePostListAdapter(listener, onDeleteButtonClicked, onEditButtonClicked)
+@BindingAdapter("blocks", "listener", "onDeleteButtonClick", "onEditButtonClick", "onCheckButtonClick")
+fun RecyclerView.bindRecyclerViewAdapter(blocks: List<PostBlockState>, listener: (Int, String) -> Unit, onDeleteButtonClicked: (Int) -> Unit, onEditButtonClicked: (Int) -> Unit, onCheckButtonClicked: (Int) -> Unit) {
+    if (adapter == null) adapter = CreatePostListAdapter(listener, onDeleteButtonClicked, onEditButtonClicked, onCheckButtonClicked)
 
     when {
         // 아이템 추가

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostUiState.kt
@@ -14,11 +14,22 @@ data class CreatePostUiState(
 
 
 sealed class PostBlockState(open val content: String, open val isEditMode: Boolean) {
-    data class STRING(override val content: String = "", override val isEditMode: Boolean = false) : PostBlockState(content, isEditMode)
-    data class IMAGE(override val content: String = "", override val isEditMode: Boolean = false, val uri: Uri, val position: PositionState) : PostBlockState(content, isEditMode)
-    data class VIDEO(override val content: String = "", override val isEditMode: Boolean = false, val position: PositionState) : PostBlockState(content, isEditMode)
-}
+    data class STRING(override val content: String = "", override val isEditMode: Boolean = false) :
+        PostBlockState(content, isEditMode)
 
+    data class IMAGE(
+        override val content: String = "",
+        override val isEditMode: Boolean = false,
+        val uri: Uri,
+        val position: PositionState
+    ) : PostBlockState(content, isEditMode)
+
+    data class VIDEO(
+        override val content: String = "",
+        override val isEditMode: Boolean = false,
+        val position: PositionState
+    ) : PostBlockState(content, isEditMode)
+}
 
 
 data class PositionState(

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostUiState.kt
@@ -9,6 +9,8 @@ data class CreatePostUiState(
     val onDeleteButtonClicked: (position: Int) -> Unit,
     val onEditButtonClicked: (position: Int) -> Unit,
     val onCheckButtonClicked: (position: Int) -> Unit,
+    val onUpButtonClicked: (position: Int) -> Unit,
+    val onDownButtonClicked: (position: Int) -> Unit,
     val isLoading: Boolean = false,
 )
 

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostUiState.kt
@@ -4,17 +4,18 @@ import android.net.Uri
 
 data class CreatePostUiState(
     val title: String = "",
-    val postBlocks: List<PostBlockState> = mutableListOf(),
+    val postBlocks: List<PostBlockState> = listOf(),
     val onTextChanged: (position: Int, content: String) -> Unit,
     val onDeleteButtonClicked: (position: Int) -> Unit,
+    val onEditButtonClicked: (position: Int) -> Unit,
     val isLoading: Boolean = false,
 )
 
 
-sealed class PostBlockState(open val content: String) {
-    data class STRING(override val content: String = "") : PostBlockState(content)
-    data class IMAGE(override val content: String = "", val uri: Uri, val position: PositionState) : PostBlockState(content)
-    data class VIDEO(override val content: String = "", val position: PositionState) : PostBlockState(content)
+sealed class PostBlockState(open val content: String, open val isEditMode: Boolean) {
+    data class STRING(override val content: String = "", override val isEditMode: Boolean = false) : PostBlockState(content, isEditMode)
+    data class IMAGE(override val content: String = "", override val isEditMode: Boolean = false, val uri: Uri, val position: PositionState) : PostBlockState(content, isEditMode)
+    data class VIDEO(override val content: String = "", override val isEditMode: Boolean = false, val position: PositionState) : PostBlockState(content, isEditMode)
 }
 
 

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostUiState.kt
@@ -8,6 +8,7 @@ data class CreatePostUiState(
     val onTextChanged: (position: Int, content: String) -> Unit,
     val onDeleteButtonClicked: (position: Int) -> Unit,
     val onEditButtonClicked: (position: Int) -> Unit,
+    val onCheckButtonClicked: (position: Int) -> Unit,
     val isLoading: Boolean = false,
 )
 

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostViewModel.kt
@@ -39,6 +39,12 @@ class CreatePostViewModel @Inject constructor(
         },
         onCheckButtonClicked = { position ->
             clearEditMode(position)
+        },
+        onUpButtonClicked = { position ->
+            moveUp(position)
+        },
+        onDownButtonClicked = { position ->
+            moveDown(position)
         }
     ))
     val uiState: StateFlow<CreatePostUiState> = _uiState.asStateFlow()
@@ -137,6 +143,28 @@ class CreatePostViewModel @Inject constructor(
                     }
                 }
             )
+        }
+    }
+
+    private fun moveUp(position: Int) {
+        if (position == 0) return
+        _uiState.update {
+            val list = it.postBlocks.toMutableList()
+            val tmp = list[position]
+            list[position] = list[position - 1]
+            list[position - 1] = tmp
+            it.copy(postBlocks = list)
+        }
+    }
+
+    private fun moveDown(position: Int) {
+        if (position == uiState.value.postBlocks.lastIndex) return
+        _uiState.update {
+            val list = it.postBlocks.toMutableList()
+            val tmp = list[position]
+            list[position] = list[position + 1]
+            list[position + 1] = tmp
+            it.copy(postBlocks = list)
         }
     }
 

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostViewModel.kt
@@ -36,6 +36,9 @@ class CreatePostViewModel @Inject constructor(
         },
         onEditButtonClicked = { position ->
             changeToEditMode(position)
+        },
+        onCheckButtonClicked = { position ->
+            clearEditMode(position)
         }
     ))
     val uiState: StateFlow<CreatePostUiState> = _uiState.asStateFlow()
@@ -113,6 +116,24 @@ class CreatePostViewModel @Inject constructor(
                             is PostBlockState.IMAGE -> postBlock.copy(isEditMode = false)
                             is PostBlockState.VIDEO -> postBlock.copy(isEditMode = false)
                         }
+                    }
+                }
+            )
+        }
+    }
+
+    private fun clearEditMode(position: Int) {
+        _uiState.update {
+            it.copy(
+                postBlocks = it.postBlocks.mapIndexed { index, postBlock ->
+                    if (position == index) {
+                        when (postBlock) {
+                            is PostBlockState.STRING -> postBlock.copy(isEditMode = false)
+                            is PostBlockState.IMAGE -> postBlock.copy(isEditMode = false)
+                            is PostBlockState.VIDEO -> postBlock.copy(isEditMode = false)
+                        }
+                    } else {
+                        postBlock
                     }
                 }
             )

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostViewModel.kt
@@ -33,6 +33,9 @@ class CreatePostViewModel @Inject constructor(
         },
         onDeleteButtonClicked = { position ->
             deletePostBlock(position)
+        },
+        onEditButtonClicked = { position ->
+            changeToEditMode(position)
         }
     ))
     val uiState: StateFlow<CreatePostUiState> = _uiState.asStateFlow()
@@ -88,6 +91,28 @@ class CreatePostViewModel @Inject constructor(
                         }
                     }else{
                         postBlock
+                    }
+                }
+            )
+        }
+    }
+
+    private fun changeToEditMode(position: Int) {
+        _uiState.update {
+            it.copy(
+                postBlocks = it.postBlocks.mapIndexed { index, postBlock ->
+                    if (position == index) {
+                        when (postBlock) {
+                            is PostBlockState.STRING -> postBlock.copy(isEditMode = true)
+                            is PostBlockState.IMAGE -> postBlock.copy(isEditMode = true)
+                            is PostBlockState.VIDEO -> postBlock.copy(isEditMode = true)
+                        }
+                    } else {
+                        when (postBlock) {
+                            is PostBlockState.STRING -> postBlock.copy(isEditMode = false)
+                            is PostBlockState.IMAGE -> postBlock.copy(isEditMode = false)
+                            is PostBlockState.VIDEO -> postBlock.copy(isEditMode = false)
+                        }
                     }
                 }
             )

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/map/MapsMarkerActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/map/MapsMarkerActivity.kt
@@ -20,7 +20,7 @@ class MapsMarkerActivity : BaseActivity<ActivityMapsMarkerBinding>(R.layout.acti
     GoogleMap.OnCameraMoveListener,
     GoogleMap.OnCameraIdleListener {
 
-    private var _post: PostBlockState = PostBlockState.IMAGE("Content", Uri.EMPTY, PositionState(37.3586926, 127.1051209))
+    private var _post: PostBlockState = PostBlockState.IMAGE("Content", false, Uri.EMPTY, PositionState(37.3586926, 127.1051209))
     private var _marker: Marker? = null
     private var _map: GoogleMap? = null
 
@@ -83,8 +83,8 @@ class MapsMarkerActivity : BaseActivity<ActivityMapsMarkerBinding>(R.layout.acti
         val newPositionState: PositionState = PositionState(latLng.latitude, latLng.longitude)
 
         marker.tag = when (tag) {
-            is PostBlockState.IMAGE -> tag.copy(tag.content, tag.uri, newPositionState)
-            is PostBlockState.VIDEO -> tag.copy(tag.content, newPositionState)
+            is PostBlockState.IMAGE -> tag.copy(tag.content, false, tag.uri, newPositionState)
+            is PostBlockState.VIDEO -> tag.copy(tag.content, false, newPositionState)
             else -> return
         }
     }

--- a/android/app/src/main/res/layout/fragment_create_post.xml
+++ b/android/app/src/main/res/layout/fragment_create_post.xml
@@ -134,6 +134,8 @@
             onDeleteButtonClick="@{vm.uiState.onDeleteButtonClicked}"
             onEditButtonClick="@{vm.uiState.onEditButtonClicked}"
             onCheckButtonClick="@{vm.uiState.onCheckButtonClicked}"
+            onUpButtonClick="@{vm.uiState.onUpButtonClicked}"
+            onDownButtonClick="@{vm.uiState.onDownButtonClicked}"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             tools:listitem="@layout/item_text_block"/>
 

--- a/android/app/src/main/res/layout/fragment_create_post.xml
+++ b/android/app/src/main/res/layout/fragment_create_post.xml
@@ -133,6 +133,7 @@
             listener="@{vm.uiState.onTextChanged}"
             onDeleteButtonClick="@{vm.uiState.onDeleteButtonClicked}"
             onEditButtonClick="@{vm.uiState.onEditButtonClicked}"
+            onCheckButtonClick="@{vm.uiState.onCheckButtonClicked}"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             tools:listitem="@layout/item_text_block"/>
 

--- a/android/app/src/main/res/layout/fragment_create_post.xml
+++ b/android/app/src/main/res/layout/fragment_create_post.xml
@@ -132,6 +132,7 @@
             blocks="@{vm.uiState.postBlocks}"
             listener="@{vm.uiState.onTextChanged}"
             onDeleteButtonClick="@{vm.uiState.onDeleteButtonClicked}"
+            onEditButtonClick="@{vm.uiState.onEditButtonClicked}"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             tools:listitem="@layout/item_text_block"/>
 

--- a/android/app/src/main/res/layout/item_image_block.xml
+++ b/android/app/src/main/res/layout/item_image_block.xml
@@ -4,6 +4,7 @@
 
     <data>
 
+        <import type="android.view.View"/>
         <import type="kotlin.jvm.functions.Function0"/>
         <import type="kotlin.Unit"/>
         <variable
@@ -12,6 +13,9 @@
         <variable
             name="uri"
             type="android.net.Uri" />
+        <variable
+            name="editMode"
+            type="Boolean" />
 
     </data>
 
@@ -26,7 +30,8 @@
             android:layout_height="0dp"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="@id/til_description"
-            app:cardBackgroundColor="@color/surfaceColor">
+            app:cardBackgroundColor="@color/surfaceColor"
+            editMode="@{editMode}">
 
         </com.google.android.material.card.MaterialCardView>
 
@@ -42,7 +47,8 @@
             android:padding="16dp"
             android:layout_marginVertical="8dp"
             app:tint="@color/errorContainer"
-            android:onClick="@{() -> onDeleteButtonClick.invoke()}"/>
+            android:onClick="@{() -> onDeleteButtonClick.invoke()}"
+            android:visibility="@{editMode ? View.INVISIBLE : View.VISIBLE}"/>
 
         <ImageButton
             android:id="@+id/btn_edit_block"
@@ -55,7 +61,8 @@
             android:background="?attr/actionBarItemBackground"
             android:padding="16dp"
             android:layout_marginEnd="8dp"
-            android:layout_marginVertical="8dp"/>
+            android:layout_marginVertical="8dp"
+            android:visibility="@{editMode ? View.INVISIBLE : View.VISIBLE}"/>
 
         <ImageButton
             android:id="@+id/btn_up"
@@ -68,7 +75,7 @@
             android:background="?attr/actionBarItemBackground"
             android:padding="16dp"
             android:layout_marginVertical="8dp"
-            android:visibility="invisible"/>
+            android:visibility="@{editMode ? View.VISIBLE : View.INVISIBLE}"/>
 
         <ImageButton
             android:id="@+id/btn_down"
@@ -81,7 +88,7 @@
             android:background="?attr/actionBarItemBackground"
             android:padding="16dp"
             android:layout_marginVertical="8dp"
-            android:visibility="invisible"/>
+            android:visibility="@{editMode ? View.VISIBLE : View.INVISIBLE}"/>
 
         <ImageButton
             android:id="@+id/btn_edit_cancel"
@@ -94,7 +101,7 @@
             android:background="?attr/actionBarItemBackground"
             android:padding="16dp"
             android:layout_marginVertical="8dp"
-            android:visibility="invisible"/>
+            android:visibility="@{editMode ? View.VISIBLE : View.INVISIBLE}"/>
 
         <ImageButton
             android:id="@+id/btn_edit_complete"
@@ -108,13 +115,14 @@
             android:padding="16dp"
             android:layout_marginEnd="8dp"
             android:layout_marginVertical="8dp"
-            android:visibility="invisible"/>
+            android:visibility="@{editMode ? View.VISIBLE : View.INVISIBLE}"/>
 
         <ImageView
             android:id="@+id/iv_image"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
+            android:layout_marginHorizontal="1dp"
             app:layout_constraintTop_toBottomOf="@id/btn_delete_block"
             uri="@{uri}"/>
 

--- a/android/app/src/main/res/layout/item_text_block.xml
+++ b/android/app/src/main/res/layout/item_text_block.xml
@@ -7,11 +7,15 @@
             name="stringBlock"
             type="com.boostcampwm2023.snappoint.presentation.createpost.PostBlockState.STRING" />
 
+        <import type="android.view.View"/>
         <import type="kotlin.jvm.functions.Function0"/>
         <import type="kotlin.Unit"/>
         <variable
             name="onDeleteButtonClick"
             type="Function0&lt;Unit>" />
+        <variable
+            name="editMode"
+            type="Boolean" />
 
     </data>
 
@@ -26,7 +30,8 @@
             android:layout_height="0dp"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="@id/til_text"
-            app:cardBackgroundColor="@color/surfaceColor">
+            app:cardBackgroundColor="@color/surfaceColor"
+            editMode="@{editMode}">
 
         </com.google.android.material.card.MaterialCardView>
 
@@ -42,7 +47,8 @@
             android:padding="16dp"
             android:layout_marginVertical="8dp"
             app:tint="@color/errorContainer"
-            android:onClick="@{() -> onDeleteButtonClick.invoke()}"/>
+            android:onClick="@{() -> onDeleteButtonClick.invoke()}"
+            android:visibility="@{editMode ? View.INVISIBLE : View.VISIBLE}"/>
 
         <ImageButton
             android:id="@+id/btn_edit_block"
@@ -55,7 +61,61 @@
             android:background="?attr/actionBarItemBackground"
             android:padding="16dp"
             android:layout_marginEnd="8dp"
-            android:layout_marginVertical="8dp"/>
+            android:layout_marginVertical="8dp"
+            android:visibility="@{editMode ? View.INVISIBLE : View.VISIBLE}"/>
+
+        <ImageButton
+            android:id="@+id/btn_up"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toStartOf="@id/btn_down"
+            app:layout_constraintTop_toTopOf="@id/cv_text"
+            app:layout_constraintBottom_toTopOf="@id/til_text"
+            android:src="@drawable/icon_arrow_up"
+            android:background="?attr/actionBarItemBackground"
+            android:padding="16dp"
+            android:layout_marginVertical="8dp"
+            android:visibility="@{editMode ? View.VISIBLE : View.INVISIBLE}"/>
+
+        <ImageButton
+            android:id="@+id/btn_down"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toStartOf="@id/btn_edit_cancel"
+            app:layout_constraintTop_toTopOf="@id/cv_text"
+            app:layout_constraintBottom_toTopOf="@id/til_text"
+            android:src="@drawable/icon_arrow_down"
+            android:background="?attr/actionBarItemBackground"
+            android:padding="16dp"
+            android:layout_marginVertical="8dp"
+            android:visibility="@{editMode ? View.VISIBLE : View.INVISIBLE}"/>
+
+        <ImageButton
+            android:id="@+id/btn_edit_cancel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toStartOf="@id/btn_edit_block"
+            app:layout_constraintTop_toTopOf="@id/cv_text"
+            app:layout_constraintBottom_toTopOf="@id/til_text"
+            android:src="@drawable/icon_cancel"
+            android:background="?attr/actionBarItemBackground"
+            android:padding="16dp"
+            android:layout_marginVertical="8dp"
+            android:visibility="@{editMode ? View.VISIBLE : View.INVISIBLE}"/>
+
+        <ImageButton
+            android:id="@+id/btn_edit_complete"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="@id/cv_text"
+            app:layout_constraintTop_toTopOf="@id/cv_text"
+            app:layout_constraintBottom_toTopOf="@id/til_text"
+            android:src="@drawable/icon_check"
+            android:background="?attr/actionBarItemBackground"
+            android:padding="16dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginVertical="8dp"
+            android:visibility="@{editMode ? View.VISIBLE : View.INVISIBLE}"/>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/til_text"


### PR DESCRIPTION
## 작업 개요
- [x] 블록의 수정 버튼을 클릭하면 편집 모드로 전환된다.
- [x] 편집 모드에서 위 또는 아래 버튼을 클릭하면 블록의 위치가 해당 방향과 변경된다.
- [x] 편집 모드에서 체크 버튼을 누르면 편집 모드가 해제된다.

## 작업 사항
- 게시물 블록의 수정 버튼을 클릭하면 해당 블록이 하이라이트되고, 버튼이 바뀌는 편집 모드가 된다.
- 편집 모드에서 위 또는 아래 버튼을 클릭하면 UiState의 데이터의 위치가 변경되고, RecyclerView에도 반영된다.
- 편집 모드에서 체크 버튼을 누르게 되면 다시 이전 상태로 복구된다.

## 고민한 점들
- 순서를 변경할 때 EditText에 포커스가 있다면 해당 포커스는 움직이지 않고 그 자리에 고정되는 문제가 있었습니다.
- 일단 수정 버튼이나 위 아래 버튼을 클릭하면 포커스가 해제되도록 구현하였습니다.

## 스크린샷