### PR TITLE
Feature(#30): 게시글 목록 확인

### DIFF
--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundFragment.kt
@@ -1,8 +1,26 @@
 package com.boostcampwm2023.snappoint.presentation.around
 
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.viewModels
 import com.boostcampwm2023.snappoint.R
 import com.boostcampwm2023.snappoint.databinding.FragmentAroundBinding
 import com.boostcampwm2023.snappoint.presentation.base.BaseFragment
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class AroundFragment : BaseFragment<FragmentAroundBinding>(R.layout.fragment_around) {
+
+    private val viewModel: AroundViewModel by viewModels()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initBinding()
+    }
+
+    private fun initBinding() {
+        with(binding) {
+            vm = viewModel
+        }
+    }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundUiState.kt
@@ -1,0 +1,11 @@
+package com.boostcampwm2023.snappoint.presentation.around
+
+data class AroundUiState(
+    val posts: List<PostState> = emptyList()
+)
+
+data class PostState(
+    val author: String,
+    val timeStamp: String,
+    val body: String
+)

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundUiState.kt
@@ -5,6 +5,7 @@ data class AroundUiState(
 )
 
 data class PostState(
+    val title: String,
     val author: String,
     val timeStamp: String,
     val body: String

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundViewModel.kt
@@ -1,0 +1,13 @@
+package com.boostcampwm2023.snappoint.presentation.around
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+class AroundViewModel @Inject constructor() : ViewModel() {
+
+    private val _uiState: MutableStateFlow<AroundUiState> = MutableStateFlow(AroundUiState())
+    val uiState: StateFlow<AroundUiState> = _uiState.asStateFlow()
+}

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundViewModel.kt
@@ -4,10 +4,43 @@ import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 class AroundViewModel @Inject constructor() : ViewModel() {
 
     private val _uiState: MutableStateFlow<AroundUiState> = MutableStateFlow(AroundUiState())
     val uiState: StateFlow<AroundUiState> = _uiState.asStateFlow()
+
+    init {
+        _uiState.update {
+            it.copy(
+                posts = listOf(
+                    PostState(
+                        title = "노잼도시 청주를 여행해보자",
+                        author = "양희범",
+                        timeStamp = "1 Days Ago",
+                        body = "동해물과 백두산이 마르고 닳도록 하느님이 보우하사 우리나라 만세 무궁화 삼천리 화려강산 대한사람 대한으로 길이 보전하세"
+                    ),
+                    PostState(
+                        title = "청주의 정통 맛집을 찾아서",
+                        author = "주재현",
+                        timeStamp = "2 Weeks Ago",
+                        body = ""
+                    ),
+                    PostState(
+                        title = "청주 야경 맛집 7선",
+                        author = "이정건",
+                        timeStamp = "3 Months Ago",
+                        body = ""
+                    ),
+                    PostState(title = "안녕하세요",
+                        author = "원승빈",
+                        timeStamp = "4 Years Ago",
+                        body = ""
+                    )
+                )
+            )
+        }
+    }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundViewModel.kt
@@ -1,12 +1,14 @@
 package com.boostcampwm2023.snappoint.presentation.around
 
 import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
+@HiltViewModel
 class AroundViewModel @Inject constructor() : ViewModel() {
 
     private val _uiState: MutableStateFlow<AroundUiState> = MutableStateFlow(AroundUiState())

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/PostItemViewHolder.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/PostItemViewHolder.kt
@@ -1,0 +1,4 @@
+package com.boostcampwm2023.snappoint.presentation.around
+
+class PostItemViewHolder {
+}

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/PostItemViewHolder.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/PostItemViewHolder.kt
@@ -1,4 +1,13 @@
 package com.boostcampwm2023.snappoint.presentation.around
 
-class PostItemViewHolder {
+import androidx.recyclerview.widget.RecyclerView
+import com.boostcampwm2023.snappoint.databinding.ItemAroundPostBinding
+
+class PostItemViewHolder(private val binding: ItemAroundPostBinding) :
+    RecyclerView.ViewHolder(binding.root) {
+
+    fun bind(item: PostState) {
+        binding.tvPostTitle.text = item.title
+        binding.tvPostTimestamp.text = item.timeStamp
+    }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/PostListAdapter.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/PostListAdapter.kt
@@ -1,4 +1,40 @@
 package com.boostcampwm2023.snappoint.presentation.around
 
-class PostListAdapter {
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.databinding.BindingAdapter
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.boostcampwm2023.snappoint.databinding.ItemAroundPostBinding
+
+class PostListAdapter() : ListAdapter<PostState, PostItemViewHolder>(diffUtil) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PostItemViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        return PostItemViewHolder(ItemAroundPostBinding.inflate(inflater, parent, false))
+    }
+
+    override fun onBindViewHolder(holder: PostItemViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    companion object {
+        val diffUtil = object : DiffUtil.ItemCallback<PostState>() {
+            override fun areItemsTheSame(oldItem: PostState, newItem: PostState): Boolean {
+                return oldItem == newItem
+            }
+
+            override fun areContentsTheSame(oldItem: PostState, newItem: PostState): Boolean {
+                return oldItem == newItem
+            }
+
+        }
+    }
+}
+
+@BindingAdapter("posts")
+fun RecyclerView.bindRecyclerViewAdapter(posts: List<PostState>) {
+    if (adapter == null) adapter = PostListAdapter()
+    (adapter as PostListAdapter).submitList(posts)
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/PostListAdapter.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/PostListAdapter.kt
@@ -1,0 +1,4 @@
+package com.boostcampwm2023.snappoint.presentation.around
+
+class PostListAdapter {
+}

--- a/android/app/src/main/res/layout/fragment_around.xml
+++ b/android/app/src/main/res/layout/fragment_around.xml
@@ -5,6 +5,10 @@
 
     <data>
 
+        <variable
+            name="vm"
+            type="com.boostcampwm2023.snappoint.presentation.around.AroundViewModel" />
+
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/android/app/src/main/res/layout/fragment_around.xml
+++ b/android/app/src/main/res/layout/fragment_around.xml
@@ -1,21 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
 
     </data>
 
-    <FrameLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@color/surfaceContainerLow"
         tools:context=".presentation.around.AroundFragment">
 
-        <!-- TODO: Update blank fragment layout -->
         <TextView
+            android:id="@+id/tv_title_around"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:text="around fragment" />
+            android:layout_height="wrap_content"
+            android:text="@string/around_title"
+            android:textSize="22sp"
+            android:layout_marginStart="36dp"
+            app:layout_constraintTop_toTopOf="parent" />
 
-    </FrameLayout>
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rcv_around_post"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toBottomOf="@id/tv_title_around"
+            app:layout_constraintBottom_toBottomOf="parent"
+            android:padding="20dp"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            tools:listitem="@layout/item_around_post" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/app/src/main/res/layout/fragment_around.xml
+++ b/android/app/src/main/res/layout/fragment_around.xml
@@ -34,6 +34,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             android:padding="20dp"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            posts="@{vm.uiState.posts}"
             tools:listitem="@layout/item_around_post" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/layout/item_around_post.xml
+++ b/android/app/src/main/res/layout/item_around_post.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/cv_around_post"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:cardBackgroundColor="@color/surfaceColor"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="@id/iv_profile"
+        android:layout_marginBottom="12dp"/>
+
+    <ImageView
+        android:id="@+id/iv_profile"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginVertical="16dp"
+        app:layout_constraintStart_toStartOf="@id/cv_around_post"
+        app:layout_constraintTop_toTopOf="@id/cv_around_post"
+        app:layout_constraintBottom_toBottomOf="@id/cv_around_post"/>
+
+    <TextView
+        android:id="@+id/tv_post_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        tools:text="제목"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        android:layout_marginStart="16dp"
+        android:layout_marginBottom="4dp"
+        app:layout_constraintStart_toEndOf="@id/iv_profile"
+        app:layout_constraintTop_toTopOf="@id/cv_around_post"
+        app:layout_constraintBottom_toTopOf="@id/tv_post_timestamp"
+        app:layout_constraintVertical_chainStyle="packed" />
+
+    <TextView
+        android:id="@+id/tv_post_timestamp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        tools:text="1 Days Ago"
+        android:textSize="14sp"
+        app:layout_constraintStart_toStartOf="@id/tv_post_title"
+        app:layout_constraintTop_toBottomOf="@id/tv_post_title"
+        app:layout_constraintBottom_toBottomOf="@id/cv_around_post"/>
+
+    <ImageButton
+        android:id="@+id/btn_expand"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/icon_arrow_down"
+        android:background="?attr/actionBarItemBackground"
+        android:padding="16dp"
+        android:layout_marginVertical="12dp"
+        android:layout_marginEnd="4dp"
+        app:layout_constraintEnd_toEndOf="@id/cv_around_post"
+        app:layout_constraintTop_toTopOf="@id/cv_around_post"
+        app:layout_constraintBottom_toBottomOf="@id/cv_around_post"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/layout/item_around_post.xml
+++ b/android/app/src/main/res/layout/item_around_post.xml
@@ -1,64 +1,71 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <com.google.android.material.card.MaterialCardView
-        android:id="@+id/cv_around_post"
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        app:cardBackgroundColor="@color/surfaceColor"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="@id/iv_profile"
-        android:layout_marginBottom="12dp"/>
+        android:layout_height="wrap_content">
 
-    <ImageView
-        android:id="@+id/iv_profile"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginVertical="16dp"
-        app:layout_constraintStart_toStartOf="@id/cv_around_post"
-        app:layout_constraintTop_toTopOf="@id/cv_around_post"
-        app:layout_constraintBottom_toBottomOf="@id/cv_around_post"/>
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/cv_around_post"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:cardBackgroundColor="@color/surfaceColor"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="@id/iv_profile"
+            android:layout_marginBottom="12dp" />
 
-    <TextView
-        android:id="@+id/tv_post_title"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        tools:text="제목"
-        android:textSize="16sp"
-        android:textStyle="bold"
-        android:layout_marginStart="16dp"
-        android:layout_marginBottom="4dp"
-        app:layout_constraintStart_toEndOf="@id/iv_profile"
-        app:layout_constraintTop_toTopOf="@id/cv_around_post"
-        app:layout_constraintBottom_toTopOf="@id/tv_post_timestamp"
-        app:layout_constraintVertical_chainStyle="packed" />
+        <ImageView
+            android:id="@+id/iv_profile"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginVertical="16dp"
+            app:layout_constraintStart_toStartOf="@id/cv_around_post"
+            app:layout_constraintTop_toTopOf="@id/cv_around_post"
+            app:layout_constraintBottom_toBottomOf="@id/cv_around_post" />
 
-    <TextView
-        android:id="@+id/tv_post_timestamp"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        tools:text="1 Days Ago"
-        android:textSize="14sp"
-        app:layout_constraintStart_toStartOf="@id/tv_post_title"
-        app:layout_constraintTop_toBottomOf="@id/tv_post_title"
-        app:layout_constraintBottom_toBottomOf="@id/cv_around_post"/>
+        <TextView
+            android:id="@+id/tv_post_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            tools:text="제목"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            android:layout_marginStart="16dp"
+            android:layout_marginBottom="4dp"
+            app:layout_constraintStart_toEndOf="@id/iv_profile"
+            app:layout_constraintTop_toTopOf="@id/cv_around_post"
+            app:layout_constraintBottom_toTopOf="@id/tv_post_timestamp"
+            app:layout_constraintVertical_chainStyle="packed" />
 
-    <ImageButton
-        android:id="@+id/btn_expand"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/icon_arrow_down"
-        android:background="?attr/actionBarItemBackground"
-        android:padding="16dp"
-        android:layout_marginVertical="12dp"
-        android:layout_marginEnd="4dp"
-        app:layout_constraintEnd_toEndOf="@id/cv_around_post"
-        app:layout_constraintTop_toTopOf="@id/cv_around_post"
-        app:layout_constraintBottom_toBottomOf="@id/cv_around_post"/>
+        <TextView
+            android:id="@+id/tv_post_timestamp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            tools:text="1 Days Ago"
+            android:textSize="14sp"
+            app:layout_constraintStart_toStartOf="@id/tv_post_title"
+            app:layout_constraintTop_toBottomOf="@id/tv_post_title"
+            app:layout_constraintBottom_toBottomOf="@id/cv_around_post" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <ImageButton
+            android:id="@+id/btn_expand"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/icon_arrow_down"
+            android:background="?attr/actionBarItemBackground"
+            android:padding="16dp"
+            android:layout_marginVertical="12dp"
+            android:layout_marginEnd="4dp"
+            app:layout_constraintEnd_toEndOf="@id/cv_around_post"
+            app:layout_constraintTop_toTopOf="@id/cv_around_post"
+            app:layout_constraintBottom_toBottomOf="@id/cv_around_post" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -18,4 +18,5 @@
     <string name="menu_subscription">구독</string>
     <string name="menu_popular_post">인기글</string>
     <string name="menu_settings">설정</string>
+    <string name="around_title">주변 게시글</string>
 </resources>


### PR DESCRIPTION
## 작업 개요
- [x] 게시글 목록 화면 UI 레이아웃 구성
- [x] 게시글 목록 화면의 `ViewModel`과 `UiState` 작성
- [x] 게시글 목록을 보여주는 `RecyclerView` 구현

## 작업 사항
- 게시글 목록 화면의 UI 레이아웃을 XML로 작성하였습니다.
- 주변 게시글 목록 화면인 `AroundFragment`의 `ViewModel`과 `UiState`를 작성하였습니다.
- 주변 게시글 목록을 보여주는 `RecyclerView`를 `ListAdapter`를 이용하여 구현하였습니다.
- `ListAdapter`의 아이템은 `UiState`의 `posts`를 사용하고, `BindingAdapter`로 `RecyclerView`를 초기화하도록 구현하였습니다.

## 스크린샷(필수 X)
<image src=https://github.com/boostcampwm2023/and01-SnapPoint/assets/85796984/7621ded7-01ec-479f-ab60-2451a3f1c45d width=270 height=600>