### PR TITLE
Feature(#104): 메인 화면에서 게시글 목록을 보유하도록 하기

### DIFF
--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/mapper/PostMapper.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/mapper/PostMapper.kt
@@ -4,8 +4,8 @@ import android.net.Uri
 import com.boostcampwm2023.snappoint.data.remote.model.BlockType
 import com.boostcampwm2023.snappoint.data.remote.model.Position
 import com.boostcampwm2023.snappoint.data.remote.model.PostBlock
-import com.boostcampwm2023.snappoint.presentation.createpost.PositionState
-import com.boostcampwm2023.snappoint.presentation.createpost.PostBlockState
+import com.boostcampwm2023.snappoint.presentation.model.PositionState
+import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
 
 fun PostBlock.asPostBlockState(): PostBlockState {
     return when(type){

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/repository/PostRepository.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/repository/PostRepository.kt
@@ -1,6 +1,6 @@
 package com.boostcampwm2023.snappoint.data.repository
 
-import com.boostcampwm2023.snappoint.presentation.createpost.PostBlockState
+import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
 import kotlinx.coroutines.flow.Flow
 
 interface PostRepository {

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/repository/PostRepositoryImpl.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/repository/PostRepositoryImpl.kt
@@ -3,7 +3,7 @@ package com.boostcampwm2023.snappoint.data.repository
 import com.boostcampwm2023.snappoint.data.mapper.asPostBlock
 import com.boostcampwm2023.snappoint.data.remote.SnapPointApi
 import com.boostcampwm2023.snappoint.data.remote.model.request.CreatePostRequest
-import com.boostcampwm2023.snappoint.presentation.createpost.PostBlockState
+import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundFragment.kt
@@ -2,25 +2,43 @@ package com.boostcampwm2023.snappoint.presentation.around
 
 import android.os.Bundle
 import android.view.View
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.boostcampwm2023.snappoint.R
 import com.boostcampwm2023.snappoint.databinding.FragmentAroundBinding
 import com.boostcampwm2023.snappoint.presentation.base.BaseFragment
+import com.boostcampwm2023.snappoint.presentation.main.MainViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class AroundFragment : BaseFragment<FragmentAroundBinding>(R.layout.fragment_around) {
 
-    private val viewModel: AroundViewModel by viewModels()
+    private val aroundViewModel: AroundViewModel by viewModels()
+    private val mainViewModel: MainViewModel by activityViewModels()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initBinding()
+        collectViewModelData()
+    }
+
+    private fun collectViewModelData() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.RESUMED){
+                mainViewModel.uiState.collect{
+                    aroundViewModel.updatePosts(it.posts)
+                }
+            }
+        }
     }
 
     private fun initBinding() {
         with(binding) {
-            vm = viewModel
+            vm = aroundViewModel
         }
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundViewModel.kt
@@ -1,6 +1,8 @@
 package com.boostcampwm2023.snappoint.presentation.around
 
 import androidx.lifecycle.ViewModel
+import com.boostcampwm2023.snappoint.presentation.main.MainUiState
+import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -9,12 +11,19 @@ import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 @HiltViewModel
-class AroundViewModel @Inject constructor() : ViewModel() {
+class AroundViewModel @Inject constructor(
+
+) : ViewModel() {
 
     private val _uiState: MutableStateFlow<AroundUiState> = MutableStateFlow(AroundUiState())
     val uiState: StateFlow<AroundUiState> = _uiState.asStateFlow()
 
-    init {
 
+    fun updatePosts(posts: List<PostSummaryState>) {
+        _uiState.update {
+            it.copy(
+                posts = posts
+            )
+        }
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundViewModel.kt
@@ -15,34 +15,6 @@ class AroundViewModel @Inject constructor() : ViewModel() {
     val uiState: StateFlow<AroundUiState> = _uiState.asStateFlow()
 
     init {
-        _uiState.update {
-            it.copy(
-                posts = listOf(
-                    PostState(
-                        title = "노잼도시 청주를 여행해보자",
-                        author = "양희범",
-                        timeStamp = "1 Days Ago",
-                        body = "동해물과 백두산이 마르고 닳도록 하느님이 보우하사 우리나라 만세 무궁화 삼천리 화려강산 대한사람 대한으로 길이 보전하세"
-                    ),
-                    PostState(
-                        title = "청주의 정통 맛집을 찾아서",
-                        author = "주재현",
-                        timeStamp = "2 Weeks Ago",
-                        body = ""
-                    ),
-                    PostState(
-                        title = "청주 야경 맛집 7선",
-                        author = "이정건",
-                        timeStamp = "3 Months Ago",
-                        body = ""
-                    ),
-                    PostState(title = "안녕하세요",
-                        author = "원승빈",
-                        timeStamp = "4 Years Ago",
-                        body = ""
-                    )
-                )
-            )
-        }
+
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/PostItemViewHolder.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/PostItemViewHolder.kt
@@ -2,11 +2,13 @@ package com.boostcampwm2023.snappoint.presentation.around
 
 import androidx.recyclerview.widget.RecyclerView
 import com.boostcampwm2023.snappoint.databinding.ItemAroundPostBinding
+import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
+import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
 
 class PostItemViewHolder(private val binding: ItemAroundPostBinding) :
     RecyclerView.ViewHolder(binding.root) {
 
-    fun bind(item: PostState) {
+    fun bind(item: PostSummaryState) {
         binding.tvPostTitle.text = item.title
         binding.tvPostTimestamp.text = item.timeStamp
     }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/PostListAdapter.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/PostListAdapter.kt
@@ -7,8 +7,10 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.boostcampwm2023.snappoint.databinding.ItemAroundPostBinding
+import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
 
-class PostListAdapter() : ListAdapter<PostState, PostItemViewHolder>(diffUtil) {
+class PostListAdapter(
+) : ListAdapter<PostSummaryState, PostItemViewHolder>(diffUtil) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PostItemViewHolder {
         val inflater = LayoutInflater.from(parent.context)
@@ -20,12 +22,12 @@ class PostListAdapter() : ListAdapter<PostState, PostItemViewHolder>(diffUtil) {
     }
 
     companion object {
-        val diffUtil = object : DiffUtil.ItemCallback<PostState>() {
-            override fun areItemsTheSame(oldItem: PostState, newItem: PostState): Boolean {
+        val diffUtil = object : DiffUtil.ItemCallback<PostSummaryState>() {
+            override fun areItemsTheSame(oldItem: PostSummaryState, newItem: PostSummaryState): Boolean {
                 return oldItem == newItem
             }
 
-            override fun areContentsTheSame(oldItem: PostState, newItem: PostState): Boolean {
+            override fun areContentsTheSame(oldItem: PostSummaryState, newItem: PostSummaryState): Boolean {
                 return oldItem == newItem
             }
 
@@ -34,7 +36,7 @@ class PostListAdapter() : ListAdapter<PostState, PostItemViewHolder>(diffUtil) {
 }
 
 @BindingAdapter("posts")
-fun RecyclerView.bindRecyclerViewAdapter(posts: List<PostState>) {
+fun RecyclerView.bindRecyclerViewAdapter(posts: List<PostSummaryState>) {
     if (adapter == null) adapter = PostListAdapter()
     (adapter as PostListAdapter).submitList(posts)
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/BlockItemViewHolder.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/BlockItemViewHolder.kt
@@ -11,6 +11,7 @@ import androidx.recyclerview.widget.RecyclerView
 import coil.load
 import com.boostcampwm2023.snappoint.databinding.ItemImageBlockBinding
 import com.boostcampwm2023.snappoint.databinding.ItemTextBlockBinding
+import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
 import com.google.android.material.card.MaterialCardView
 
 sealed class BlockItemViewHolder(

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostEvent.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostEvent.kt
@@ -1,5 +1,7 @@
 package com.boostcampwm2023.snappoint.presentation.createpost
 
+import com.boostcampwm2023.snappoint.presentation.model.PositionState
+
 sealed class CreatePostEvent {
     data class ShowMessage(val resId: Int): CreatePostEvent()
     data class FindAddress(val index: Int, val position: PositionState) : CreatePostEvent()

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostFragment.kt
@@ -20,6 +20,7 @@ import com.boostcampwm2023.snappoint.R
 import com.boostcampwm2023.snappoint.databinding.FragmentCreatePostBinding
 import com.boostcampwm2023.snappoint.presentation.base.BaseFragment
 import com.boostcampwm2023.snappoint.presentation.markerpointselector.MarkerPointSelectorActivity
+import com.boostcampwm2023.snappoint.presentation.model.PositionState
 import com.boostcampwm2023.snappoint.presentation.util.MetadataUtil
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostListAdapter.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostListAdapter.kt
@@ -6,6 +6,7 @@ import androidx.databinding.BindingAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.boostcampwm2023.snappoint.databinding.ItemImageBlockBinding
 import com.boostcampwm2023.snappoint.databinding.ItemTextBlockBinding
+import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
 
 class CreatePostListAdapter(
     private val onAddressIconClicked: (Int) -> Unit,

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostUiState.kt
@@ -1,6 +1,7 @@
 package com.boostcampwm2023.snappoint.presentation.createpost
 
 import android.net.Uri
+import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
 
 data class CreatePostUiState(
     val title: String = "",
@@ -16,17 +17,3 @@ data class CreatePostUiState(
 )
 
 
-sealed class PostBlockState(open val content: String, open val isEditMode: Boolean) {
-    data class STRING(override val content: String = "", override val isEditMode: Boolean = false) : PostBlockState(content, isEditMode)
-    data class IMAGE(override val content: String = "", val uri: Uri, val position: PositionState, val address: String = "", override val isEditMode: Boolean = false) : PostBlockState(content, isEditMode)
-    data class VIDEO(override val content: String = "", val uri: Uri, val position: PositionState, val address: String = "", override val isEditMode: Boolean = false) : PostBlockState(content, isEditMode)
-}
-
-data class PositionState(
-    val latitude: Double,
-    val longitude: Double
-){
-    fun asDoubleArray(): DoubleArray{
-        return doubleArrayOf(latitude, longitude)
-    }
-}

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostViewModel.kt
@@ -1,11 +1,13 @@
 package com.boostcampwm2023.snappoint.presentation.createpost
 
-import android.util.Log
 import android.net.Uri
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.boostcampwm2023.snappoint.R
 import com.boostcampwm2023.snappoint.data.repository.PostRepository
+import com.boostcampwm2023.snappoint.presentation.model.PositionState
+import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainUiState.kt
@@ -1,8 +1,7 @@
-package com.boostcampwm2023.snappoint.presentation.around
+package com.boostcampwm2023.snappoint.presentation.main
 
 import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
 
-data class AroundUiState(
+data class MainUiState(
     val posts: List<PostSummaryState> = emptyList()
 )
-

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
@@ -1,24 +1,96 @@
 package com.boostcampwm2023.snappoint.presentation.main
 
 import androidx.lifecycle.ViewModel
+import com.boostcampwm2023.snappoint.data.repository.PostRepository
+import com.boostcampwm2023.snappoint.presentation.model.PositionState
+import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
+import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 @HiltViewModel
-class MainViewModel @Inject constructor()
-    :ViewModel(){
+class MainViewModel @Inject constructor(
+    private val postRepository: PostRepository
+) :ViewModel(){
 
-        private val _event: MutableSharedFlow<MainActivityEvent> = MutableSharedFlow(
-            extraBufferCapacity = 1,
-            onBufferOverflow = BufferOverflow.DROP_OLDEST
-        )
-        val event: SharedFlow<MainActivityEvent> = _event.asSharedFlow()
 
-        fun drawerIconClicked() {
-            _event.tryEmit(MainActivityEvent.OpenDrawer)
+    private val _uiState: MutableStateFlow<MainUiState> = MutableStateFlow(MainUiState())
+    val uiState: StateFlow<MainUiState> = _uiState.asStateFlow()
+
+    private val _event: MutableSharedFlow<MainActivityEvent> = MutableSharedFlow(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+    val event: SharedFlow<MainActivityEvent> = _event.asSharedFlow()
+
+    fun drawerIconClicked() {
+        _event.tryEmit(MainActivityEvent.OpenDrawer)
+    }
+    init{
+        loadPosts()
+    }
+
+    private fun loadPosts() {
+        _uiState.update {
+            MainUiState(
+                posts = listOf(
+                    PostSummaryState(
+                        title = "하이",
+                        author = "원승빈",
+                        timeStamp = "123",
+                        postBlocks = listOf(
+                            PostBlockState.STRING(
+                                content = "안녕하세요, 하하"
+                            ),
+                            PostBlockState.IMAGE(
+                                content = "https://health.chosun.com/site/data/img_dir/2023/07/17/2023071701753_0.jpg",
+                                position = PositionState(10.0, 10.0),
+                                description = "고양이입니다.",
+                                address = "고양이를 발견한 동네"
+                            )
+                        )
+                    ),
+                    PostSummaryState(
+                        title = "놀러갔다온썰푼다",
+                        author = "이정건",
+                        timeStamp = "456",
+                        postBlocks = listOf(
+                            PostBlockState.IMAGE(
+                                content = "https://pds.joongang.co.kr/news/component/htmlphoto_mmdata/201901/20/28017477-0365-4a43-b546-008b603da621.jpg",
+                                position = PositionState(10.000002, 10.000002),
+                                description = "강아징입니다.",
+                                address = "내가 키우는 강아지"
+                            ),
+                            PostBlockState.STRING(
+                                content = "ㅎㅇ염"
+                            ),
+                        )
+                    ),PostSummaryState(
+                        title = "여기좋아용",
+                        author = "안언수",
+                        timeStamp = "678",
+                        postBlocks = listOf(
+                            PostBlockState.STRING(
+                                content = "동물원갔다왔슴다 ㅋ"
+                            ),
+                            PostBlockState.IMAGE(
+                                content = "https://i.namu.wiki/i/Nvsy3_i1lyInOB79UBbcDeR6MocJ4C8TBN8NjepPwqTnojCbb3Xwge9gQXfAGgW74ZA3c3i16odhBLE0bSwgFA.webp",
+                                position = PositionState(10.000004, 10.000003),
+                                description = "이것은 악어~",
+                                address = "제일 좋아하는 동물이에용"
+                            )
+                        )
+                    ),
+                )
+            )
         }
+    }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/markerpointselector/MarkerPointSelectorActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/markerpointselector/MarkerPointSelectorActivity.kt
@@ -5,8 +5,8 @@ import android.os.Bundle
 import com.boostcampwm2023.snappoint.R
 import com.boostcampwm2023.snappoint.databinding.ActivityMapsMarkerBinding
 import com.boostcampwm2023.snappoint.presentation.base.BaseActivity
-import com.boostcampwm2023.snappoint.presentation.createpost.PositionState
-import com.boostcampwm2023.snappoint.presentation.createpost.PostBlockState
+import com.boostcampwm2023.snappoint.presentation.model.PositionState
+import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.OnMapReadyCallback
@@ -101,8 +101,8 @@ class MarkerPointSelectorActivity : BaseActivity<ActivityMapsMarkerBinding>(R.la
         val newPositionState: PositionState = PositionState(latLng.latitude, latLng.longitude)
 
         marker.tag = when (tag) {
-            is PostBlockState.IMAGE -> tag.copy(tag.content, tag.uri, newPositionState)
-            is PostBlockState.VIDEO -> tag.copy(tag.content, tag.uri, newPositionState)
+            is PostBlockState.IMAGE -> tag.copy(tag.content, tag.uri, position = newPositionState)
+            is PostBlockState.VIDEO -> tag.copy(tag.content, tag.uri, position = newPositionState)
             else -> return
         }
     }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/model/Post.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/model/Post.kt
@@ -1,0 +1,25 @@
+package com.boostcampwm2023.snappoint.presentation.model
+
+import android.net.Uri
+
+data class PostSummaryState(
+    val title: String,
+    val author: String,
+    val timeStamp: String,
+    val postBlocks: List<PostBlockState>
+)
+
+sealed class PostBlockState(open val content: String, open val isEditMode: Boolean) {
+    data class STRING(override val content: String = "", override val isEditMode: Boolean = false) : PostBlockState(content, isEditMode)
+    data class IMAGE(override val content: String = "", val uri: Uri, val position: PositionState, val address: String = "", override val isEditMode: Boolean = false) : PostBlockState(content, isEditMode)
+    data class VIDEO(override val content: String = "", val uri: Uri, val position: PositionState, val address: String = "", override val isEditMode: Boolean = false) : PostBlockState(content, isEditMode)
+}
+
+data class PositionState(
+    val latitude: Double,
+    val longitude: Double
+){
+    fun asDoubleArray(): DoubleArray{
+        return doubleArrayOf(latitude, longitude)
+    }
+}

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/model/Post.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/model/Post.kt
@@ -11,8 +11,8 @@ data class PostSummaryState(
 
 sealed class PostBlockState(open val content: String, open val isEditMode: Boolean) {
     data class STRING(override val content: String = "", override val isEditMode: Boolean = false) : PostBlockState(content, isEditMode)
-    data class IMAGE(override val content: String = "", val uri: Uri, val position: PositionState, val address: String = "", override val isEditMode: Boolean = false) : PostBlockState(content, isEditMode)
-    data class VIDEO(override val content: String = "", val uri: Uri, val position: PositionState, val address: String = "", override val isEditMode: Boolean = false) : PostBlockState(content, isEditMode)
+    data class IMAGE(override val content: String = "", val uri: Uri = Uri.EMPTY, val description: String = "", val position: PositionState = PositionState(0.0, 0.0), val address: String = "", override val isEditMode: Boolean = false) : PostBlockState(content, isEditMode)
+    data class VIDEO(override val content: String = "", val uri: Uri = Uri.EMPTY, val description: String = "", val position: PositionState = PositionState(0.0, 0.0), val address: String = "", override val isEditMode: Boolean = false) : PostBlockState(content, isEditMode)
 }
 
 data class PositionState(

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/util/MetadataUtil.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/util/MetadataUtil.kt
@@ -1,7 +1,7 @@
 package com.boostcampwm2023.snappoint.presentation.util
 
 import androidx.exifinterface.media.ExifInterface
-import com.boostcampwm2023.snappoint.presentation.createpost.PositionState
+import com.boostcampwm2023.snappoint.presentation.model.PositionState
 import java.io.InputStream
 
 object MetadataUtil {

--- a/android/app/src/main/res/layout/item_text_block.xml
+++ b/android/app/src/main/res/layout/item_text_block.xml
@@ -5,7 +5,7 @@
     <data>
         <variable
             name="stringBlock"
-            type="com.boostcampwm2023.snappoint.presentation.createpost.PostBlockState.STRING" />
+            type="com.boostcampwm2023.snappoint.presentation.model.PostBlockState.STRING" />
 
         <import type="android.view.View"/>
         <import type="kotlin.jvm.functions.Function0"/>


### PR DESCRIPTION
## 작업 개요

- [x]  메인 화면 UiState 정의
- [x]  메인 화면 게시글 mock data 생성
- [x] 게시글 목록 업데이트 event 정의 및 전달

## 작업 사항

presentation layer에 있는 post 관련 state들을 model 패키지 내부에 정의했습니다.
around fragment의 UiState 요소를 교체했습니다.
MainActivity에서 게시글의 목록을 가지고 있도록 했습니다.
속해있는 fragment에서 해당 게시물들의 list 변화를 대응할 수 있도록 구현했습니다.
