### PR TITLE
Feature(#44):  게시물을 바탕으로 지도에 snappoint 표시

### DIFF
--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.navigation.ui.setupWithNavController
 import com.boostcampwm2023.snappoint.R
 import com.boostcampwm2023.snappoint.databinding.ActivityMainBinding
 import com.boostcampwm2023.snappoint.presentation.base.BaseActivity
+import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.OnMapReadyCallback
@@ -25,11 +26,60 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
     OnMapReadyCallback
 {
     private val viewModel: MainViewModel by viewModels()
-    private var _map: GoogleMap? = null
+    private var googleMap: GoogleMap? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        initBinding()
+
+        initBottomSheetWithNavigation()
+
+        initSearchBar()
+
+        initMapApi()
+
+        collectViewModelData()
+
+    }
+
+    private fun initMapApi() {
+        val map: SupportMapFragment = supportFragmentManager.findFragmentById(R.id.fcv_main_map) as SupportMapFragment
+        map.getMapAsync(this)
+    }
+
+    private fun collectViewModelData() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.RESUMED){
+
+                launch {
+                    viewModel.event.collect{event ->
+                        when(event){
+                            MainActivityEvent.OpenDrawer -> openDrawer()
+                        }
+                    }
+                }
+                launch {
+                    viewModel.uiState.collect{uiState ->
+                        updateMarker(uiState.posts)
+
+                    }
+                }
+            }
+        }
+    }
+
+    private fun updateMarker(posts: List<PostSummaryState>) {
+
+    }
+
+    private fun initSearchBar() {
+        binding.sb.setOnClickListener {
+            binding.sv.show()
+        }
+    }
+
+    private fun initBottomSheetWithNavigation() {
         val navHostFragment =
             supportFragmentManager.findFragmentById(R.id.fcv) as NavHostFragment
         val navController = navHostFragment.findNavController()
@@ -45,25 +95,6 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
                 else -> { behavior.state = BottomSheetBehavior.STATE_HALF_EXPANDED }
             }
         }
-
-        val map: SupportMapFragment = supportFragmentManager.findFragmentById(R.id.fcv_main_map) as SupportMapFragment
-        map.getMapAsync(this)
-
-        initBinding()
-
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.RESUMED){
-                viewModel.event.collect{event ->
-                    when(event){
-                        MainActivityEvent.OpenDrawer -> openDrawer()
-                    }
-                }
-            }
-        }
-
-        binding.sb.setOnClickListener {
-            binding.sv.show()
-        }
     }
 
     private fun openDrawer() {
@@ -77,7 +108,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
     }
 
     override fun onMapReady(googleMap: GoogleMap) {
-        _map = googleMap
+        this.googleMap = googleMap
 
         googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(0.0,0.0), 17.5f))
     }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -11,14 +11,18 @@ import androidx.navigation.ui.setupWithNavController
 import com.boostcampwm2023.snappoint.R
 import com.boostcampwm2023.snappoint.databinding.ActivityMainBinding
 import com.boostcampwm2023.snappoint.presentation.base.BaseActivity
+import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
 import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
+import com.google.android.gms.maps.CameraUpdate
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.OnMapReadyCallback
 import com.google.android.gms.maps.SupportMapFragment
 import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.MarkerOptions
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
@@ -68,6 +72,28 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
     }
 
     private fun updateMarker(posts: List<PostSummaryState>) {
+        lifecycleScope.launch {
+            while(googleMap == null){
+                delay(1000)
+
+            }
+            posts.forEach {
+                it.postBlocks.forEach{
+                    when(it){
+                        is PostBlockState.IMAGE -> {
+                            googleMap?.addMarker(
+                                MarkerOptions()
+                                    .position(LatLng(it.position.latitude, it.position.longitude))
+                            )
+                        }
+                        is PostBlockState.STRING -> {}
+                        is PostBlockState.VIDEO -> {
+                        }
+                    }
+                }
+            }
+        }
+
 
     }
 
@@ -102,6 +128,6 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
     override fun onMapReady(googleMap: GoogleMap) {
         this.googleMap = googleMap
 
-        googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(0.0,0.0), 17.5f))
+        googleMap.moveCamera(CameraUpdateFactory.newLatLng(LatLng(10.0,10.0)))
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -116,6 +116,6 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
     override fun onMapReady(googleMap: GoogleMap) {
         this.googleMap = googleMap
 
-        googleMap.moveCamera(CameraUpdateFactory.newLatLng(LatLng(10.0,10.0)))
+        googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(10.0,10.0), 10f))
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -12,8 +12,6 @@ import com.boostcampwm2023.snappoint.R
 import com.boostcampwm2023.snappoint.databinding.ActivityMainBinding
 import com.boostcampwm2023.snappoint.presentation.base.BaseActivity
 import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
-import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
-import com.google.android.gms.maps.CameraUpdate
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.OnMapReadyCallback
@@ -63,38 +61,28 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
                 }
                 launch {
                     viewModel.uiState.collect{uiState ->
-                        updateMarker(uiState.posts)
-
+                        updateMarker(uiState.snapPoints)
                     }
                 }
             }
         }
     }
 
-    private fun updateMarker(posts: List<PostSummaryState>) {
+    private fun updateMarker(snapPoints: List<SnapPointState>) {
         lifecycleScope.launch {
             while(googleMap == null){
                 delay(1000)
 
             }
-            posts.forEach {
-                it.postBlocks.forEach{
-                    when(it){
-                        is PostBlockState.IMAGE -> {
-                            googleMap?.addMarker(
-                                MarkerOptions()
-                                    .position(LatLng(it.position.latitude, it.position.longitude))
-                            )
-                        }
-                        is PostBlockState.STRING -> {}
-                        is PostBlockState.VIDEO -> {
-                        }
+            googleMap?.let { map ->
+                map.clear()
+                snapPoints.forEach {
+                    it.markerOptions.forEach {
+                        map.addMarker(it)
                     }
                 }
             }
         }
-
-
     }
 
     private fun initBottomSheetWithNavigation() {

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -35,8 +35,6 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
 
         initBottomSheetWithNavigation()
 
-        initSearchBar()
-
         initMapApi()
 
         collectViewModelData()
@@ -71,12 +69,6 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
 
     private fun updateMarker(posts: List<PostSummaryState>) {
 
-    }
-
-    private fun initSearchBar() {
-        binding.sb.setOnClickListener {
-            binding.sv.show()
-        }
     }
 
     private fun initBottomSheetWithNavigation() {

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainUiState.kt
@@ -1,7 +1,15 @@
 package com.boostcampwm2023.snappoint.presentation.main
 
 import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
+import com.google.android.gms.maps.model.MarkerOptions
 
 data class MainUiState(
-    val posts: List<PostSummaryState> = emptyList()
+    val posts: List<PostSummaryState> = emptyList(),
+    val snapPoints: List<SnapPointState> = emptyList(),
+)
+
+data class SnapPointState(
+    //todo 게시물의 고유 번호로 변경
+    val index: Int,
+    val markerOptions: List<MarkerOptions>
 )

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
@@ -5,6 +5,9 @@ import com.boostcampwm2023.snappoint.data.repository.PostRepository
 import com.boostcampwm2023.snappoint.presentation.model.PositionState
 import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
 import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
+import com.google.android.gms.maps.GoogleMapOptions
+import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.MarkerOptions
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -30,6 +33,9 @@ class MainViewModel @Inject constructor(
         onBufferOverflow = BufferOverflow.DROP_OLDEST
     )
     val event: SharedFlow<MainActivityEvent> = _event.asSharedFlow()
+
+
+
 
     fun drawerIconClicked() {
         _event.tryEmit(MainActivityEvent.OpenDrawer)
@@ -92,5 +98,25 @@ class MainViewModel @Inject constructor(
                 )
             )
         }
+        createMarkers()
+    }
+
+    private fun createMarkers() {
+        _uiState.update {
+            it.copy(
+                snapPoints =
+                _uiState.value.posts.mapIndexed { index, postSummaryState ->
+                        SnapPointState(
+                            index = index,
+                            markerOptions = postSummaryState.postBlocks.filterIsInstance<PostBlockState.IMAGE>().map {
+                                    MarkerOptions().apply {
+                                        position(it.position.asLatLng())
+                                    }
+                            }
+                        )
+                }
+            )
+        }
+
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
@@ -65,7 +65,7 @@ class MainViewModel @Inject constructor(
                         postBlocks = listOf(
                             PostBlockState.IMAGE(
                                 content = "https://pds.joongang.co.kr/news/component/htmlphoto_mmdata/201901/20/28017477-0365-4a43-b546-008b603da621.jpg",
-                                position = PositionState(10.000002, 10.000002),
+                                position = PositionState(10.1, 10.1),
                                 description = "강아징입니다.",
                                 address = "내가 키우는 강아지"
                             ),
@@ -83,7 +83,7 @@ class MainViewModel @Inject constructor(
                             ),
                             PostBlockState.IMAGE(
                                 content = "https://i.namu.wiki/i/Nvsy3_i1lyInOB79UBbcDeR6MocJ4C8TBN8NjepPwqTnojCbb3Xwge9gQXfAGgW74ZA3c3i16odhBLE0bSwgFA.webp",
-                                position = PositionState(10.000004, 10.000003),
+                                position = PositionState(10.4, 10.3),
                                 description = "이것은 악어~",
                                 address = "제일 좋아하는 동물이에용"
                             )

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/model/Post.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/model/Post.kt
@@ -1,6 +1,7 @@
 package com.boostcampwm2023.snappoint.presentation.model
 
 import android.net.Uri
+import com.google.android.gms.maps.model.LatLng
 
 data class PostSummaryState(
     val title: String,
@@ -21,5 +22,8 @@ data class PositionState(
 ){
     fun asDoubleArray(): DoubleArray{
         return doubleArrayOf(latitude, longitude)
+    }
+    fun asLatLng(): LatLng{
+        return LatLng(latitude, longitude)
     }
 }

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -51,6 +51,7 @@
                 <com.google.android.material.search.SearchView
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
+                    app:layout_anchor="@id/sb"
                     android:id="@+id/sv"/>
 
                 <LinearLayout


### PR DESCRIPTION
## 작업 개요

- [x] MainActivity 함수 추상화 정리
- [x] 게시물에 존재하는 사진들을 구분하는 로직 구현 
- [x] 사진 정보를 바탕으로 uiState에 추가하고 UI에 반영하는 로직 구현

## 작업 사항

marker에 표시하기 위한 데이터를 MainActivity의 Uistate로 정의했습니다.
사진 추가 시 데이터 구조가 변경될 예정입니다.
게시물들을 구분하는 고유값이 존재해야 할 것으로 예상이 됩니다.
api가 나오지 않은 시점에서, mock 데이터를 이용하는 중에서는 post의 index 값을 게시물의 고유한 값으로 생각하고 개발하려 합니다. 의견 있으시면 말씀해주세요 :)



## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->