### PR TITLE
Feature(#6, #22): 미리보기 화면 상단 바

### DIFF
--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -5,6 +5,7 @@ import androidx.activity.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.findNavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.setupWithNavController
@@ -41,6 +42,14 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
 
         collectViewModelData()
 
+        // 임시코드
+        binding.fab.setOnClickListener {
+            BottomSheetBehavior.from(binding.bs).state = BottomSheetBehavior.STATE_HALF_EXPANDED
+            (supportFragmentManager.findFragmentById(R.id.fcv) as NavHostFragment)
+                .findNavController()
+                .navigate(R.id.action_aroundFragment_to_previewFragment)
+        }
+
     }
 
     private fun initMapApi() {
@@ -55,7 +64,22 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
                 launch {
                     viewModel.event.collect{event ->
                         when(event){
-                            MainActivityEvent.OpenDrawer -> openDrawer()
+                            MainActivityEvent.OpenDrawer -> {
+                                openDrawer()
+                            }
+                            MainActivityEvent.NavigatePrev -> {
+                                (supportFragmentManager.findFragmentById(R.id.fcv) as NavHostFragment)
+                                    .findNavController()
+                                    .popBackStack()
+                            }
+                            MainActivityEvent.NavigateClose -> {
+                                (supportFragmentManager.findFragmentById(R.id.fcv) as NavHostFragment)
+                                    .findNavController()
+                                    .popBackStack()
+                                BottomSheetBehavior
+                                    .from(binding.bs)
+                                    .state = BottomSheetBehavior.STATE_COLLAPSED
+                            }
                         }
                     }
                 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -1,10 +1,12 @@
 package com.boostcampwm2023.snappoint.presentation.main
 
 import android.os.Bundle
+import android.widget.LinearLayout
 import androidx.activity.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.NavController
 import androidx.navigation.findNavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.fragment.findNavController
@@ -31,6 +33,13 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
     private val viewModel: MainViewModel by viewModels()
     private var googleMap: GoogleMap? = null
 
+    private val navController: NavController =
+        (supportFragmentManager.findFragmentById(R.id.fcv) as NavHostFragment).findNavController()
+
+    private val bottomSheetBehavior: BottomSheetBehavior<LinearLayout> by lazy {
+        BottomSheetBehavior.from(binding.bs)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -42,14 +51,8 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
 
         collectViewModelData()
 
-        // 임시코드
-        binding.fab.setOnClickListener {
-            BottomSheetBehavior.from(binding.bs).state = BottomSheetBehavior.STATE_HALF_EXPANDED
-            (supportFragmentManager.findFragmentById(R.id.fcv) as NavHostFragment)
-                .findNavController()
-                .navigate(R.id.action_aroundFragment_to_previewFragment)
-        }
-
+        // FAB 구현할 때 삭제해 주세요!!
+        setFabClickEvent()
     }
 
     private fun initMapApi() {
@@ -68,17 +71,11 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
                                 openDrawer()
                             }
                             MainActivityEvent.NavigatePrev -> {
-                                (supportFragmentManager.findFragmentById(R.id.fcv) as NavHostFragment)
-                                    .findNavController()
-                                    .popBackStack()
+                                navController.popBackStack()
                             }
                             MainActivityEvent.NavigateClose -> {
-                                (supportFragmentManager.findFragmentById(R.id.fcv) as NavHostFragment)
-                                    .findNavController()
-                                    .popBackStack()
-                                BottomSheetBehavior
-                                    .from(binding.bs)
-                                    .state = BottomSheetBehavior.STATE_COLLAPSED
+                                navController.popBackStack()
+                                bottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
                             }
                         }
                     }
@@ -96,7 +93,6 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
         lifecycleScope.launch {
             while(googleMap == null){
                 delay(1000)
-
             }
             googleMap?.let { map ->
                 map.clear()
@@ -110,21 +106,27 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
     }
 
     private fun initBottomSheetWithNavigation() {
-        val navHostFragment =
-            supportFragmentManager.findFragmentById(R.id.fcv) as NavHostFragment
-        val navController = navHostFragment.findNavController()
         binding.bnv.setupWithNavController(navController)
-
-        val behavior = BottomSheetBehavior.from(binding.bs)
-        behavior.state = BottomSheetBehavior.STATE_HALF_EXPANDED
+        bottomSheetBehavior.state = BottomSheetBehavior.STATE_HALF_EXPANDED
 
         binding.bnv.setOnItemReselectedListener { _ ->
-            when (behavior.state) {
-                BottomSheetBehavior.STATE_HALF_EXPANDED -> { behavior.state = BottomSheetBehavior.STATE_EXPANDED }
-                BottomSheetBehavior.STATE_EXPANDED -> { behavior.state = BottomSheetBehavior.STATE_COLLAPSED }
-                else -> { behavior.state = BottomSheetBehavior.STATE_HALF_EXPANDED }
+            when (bottomSheetBehavior.state) {
+                BottomSheetBehavior.STATE_HALF_EXPANDED -> { bottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED }
+                BottomSheetBehavior.STATE_EXPANDED -> { bottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED }
+                else -> { bottomSheetBehavior.state = BottomSheetBehavior.STATE_HALF_EXPANDED }
             }
         }
+    }
+
+    private fun setFabClickEvent() {
+        binding.fab.setOnClickListener {
+            openPreviewFragment()
+        }
+    }
+
+    private fun openPreviewFragment() {
+        bottomSheetBehavior.state = BottomSheetBehavior.STATE_HALF_EXPANDED
+        navController.navigate(R.id.action_aroundFragment_to_previewFragment)
     }
 
     private fun openDrawer() {

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivityEvent.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivityEvent.kt
@@ -2,7 +2,6 @@ package com.boostcampwm2023.snappoint.presentation.main
 
 sealed class MainActivityEvent {
     data object OpenDrawer: MainActivityEvent()
-
     data object NavigatePrev: MainActivityEvent()
     data object NavigateClose: MainActivityEvent()
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivityEvent.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivityEvent.kt
@@ -2,4 +2,7 @@ package com.boostcampwm2023.snappoint.presentation.main
 
 sealed class MainActivityEvent {
     data object OpenDrawer: MainActivityEvent()
+
+    data object NavigatePrev: MainActivityEvent()
+    data object NavigateClose: MainActivityEvent()
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainUiState.kt
@@ -6,6 +6,7 @@ import com.google.android.gms.maps.model.MarkerOptions
 data class MainUiState(
     val posts: List<PostSummaryState> = emptyList(),
     val snapPoints: List<SnapPointState> = emptyList(),
+    val onPreview: Boolean = false
 )
 
 data class SnapPointState(

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainUiState.kt
@@ -6,7 +6,7 @@ import com.google.android.gms.maps.model.MarkerOptions
 data class MainUiState(
     val posts: List<PostSummaryState> = emptyList(),
     val snapPoints: List<SnapPointState> = emptyList(),
-    val onPreview: Boolean = false
+    val isPreviewFragmentShowing: Boolean = false
 )
 
 data class SnapPointState(

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
@@ -119,4 +119,20 @@ class MainViewModel @Inject constructor(
         }
 
     }
+
+    fun openPreview() {
+        _uiState.update {
+            it.copy(
+                onPreview = true
+            )
+        }
+    }
+
+    fun closePreview() {
+        _uiState.update {
+            it.copy(
+                onPreview = false
+            )
+        }
+    }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
@@ -40,6 +40,15 @@ class MainViewModel @Inject constructor(
     fun drawerIconClicked() {
         _event.tryEmit(MainActivityEvent.OpenDrawer)
     }
+
+    fun appbarBackIconClicked() {
+        _event.tryEmit(MainActivityEvent.NavigatePrev)
+    }
+
+    fun appbarCloseIconClicked() {
+        _event.tryEmit(MainActivityEvent.NavigateClose)
+    }
+
     init{
         loadPosts()
     }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
@@ -129,18 +129,18 @@ class MainViewModel @Inject constructor(
 
     }
 
-    fun openPreview() {
+    fun onPreviewFragmentShowing() {
         _uiState.update {
             it.copy(
-                onPreview = true
+                isPreviewFragmentShowing = true
             )
         }
     }
 
-    fun closePreview() {
+    fun onPreviewFragmentClosing() {
         _uiState.update {
             it.copy(
-                onPreview = false
+                isPreviewFragmentShowing = false
             )
         }
     }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/mainbindingAdapter.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/mainbindingAdapter.kt
@@ -1,6 +1,8 @@
 package com.boostcampwm2023.snappoint.presentation.main
 
+import android.widget.LinearLayout
 import androidx.databinding.BindingAdapter
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.search.SearchBar
 
 
@@ -9,4 +11,10 @@ fun bindSearchBar(view: SearchBar, event: () -> Unit){
     view.setNavigationOnClickListener {
         event.invoke()
     }
+}
+
+@BindingAdapter("draggable")
+fun LinearLayout.setDraggable(value: Boolean) {
+    val behavior = BottomSheetBehavior.from(this)
+    behavior.isDraggable = value
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/mainbindingAdapter.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/mainbindingAdapter.kt
@@ -1,7 +1,10 @@
 package com.boostcampwm2023.snappoint.presentation.main
 
+import android.annotation.SuppressLint
 import android.widget.LinearLayout
 import androidx.databinding.BindingAdapter
+import com.boostcampwm2023.snappoint.R
+import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.search.SearchBar
 
@@ -17,4 +20,21 @@ fun bindSearchBar(view: SearchBar, event: () -> Unit){
 fun LinearLayout.setDraggable(value: Boolean) {
     val behavior = BottomSheetBehavior.from(this)
     behavior.isDraggable = value
+}
+
+@BindingAdapter("navigation_icon_click")
+fun navigationIconClick(view: MaterialToolbar, event: () -> Unit) {
+    view.setNavigationOnClickListener {
+        event.invoke()
+    }
+}
+
+@BindingAdapter("menu_item_click")
+fun menuItemClick(view: MaterialToolbar, event: () -> Unit) {
+    view.setOnMenuItemClickListener {
+        when(it.itemId) {
+            R.id.preview_close -> event.invoke()
+        }
+        true
+    }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/preview/PreviewFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/preview/PreviewFragment.kt
@@ -23,7 +23,6 @@ class PreviewFragment : BaseFragment<FragmentPreviewBinding>(R.layout.fragment_p
 
     private val snapHelper: CarouselSnapHelper = CarouselSnapHelper()
     private val layoutManager: LayoutManager by lazy { binding.rcvPreview.layoutManager!! }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -36,6 +35,19 @@ class PreviewFragment : BaseFragment<FragmentPreviewBinding>(R.layout.fragment_p
                 "IDX: ${layoutManager.getPosition(snapHelper.findSnapView(layoutManager)!!)}"
             )
         }
+    }
+
+    override fun onStart() {
+        super.onStart()
+
+        mainViewModel.openPreview()
+    }
+
+
+    override fun onStop() {
+        super.onStop()
+
+        mainViewModel.closePreview()
     }
 
     private fun initBinding() {

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/preview/PreviewFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/preview/PreviewFragment.kt
@@ -23,6 +23,11 @@ class PreviewFragment : BaseFragment<FragmentPreviewBinding>(R.layout.fragment_p
 
     private val snapHelper: CarouselSnapHelper = CarouselSnapHelper()
     private val layoutManager: LayoutManager by lazy { binding.rcvPreview.layoutManager!! }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        mainViewModel.onPreviewFragmentShowing()
+    }
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -37,17 +42,9 @@ class PreviewFragment : BaseFragment<FragmentPreviewBinding>(R.layout.fragment_p
         }
     }
 
-    override fun onStart() {
-        super.onStart()
-
-        mainViewModel.openPreview()
-    }
-
-
-    override fun onStop() {
-        super.onStop()
-
-        mainViewModel.closePreview()
+    override fun onDestroy() {
+        super.onDestroy()
+        mainViewModel.onPreviewFragmentClosing()
     }
 
     private fun initBinding() {

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -45,7 +45,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:hint="@string/activity_main_sb_hint"
-                    android:visibility="@{vm.uiState.onPreview ? View.GONE : View.VISIBLE}"
+                    android:visibility="@{vm.uiState.isPreviewFragmentShowing ? View.GONE : View.VISIBLE}"
                     drawer_icon_click= "@{() -> vm.drawerIconClicked()}"
                     app:elevation="6dp"
                     app:navigationIcon="@drawable/icon_drawer"
@@ -54,7 +54,7 @@
                 <com.google.android.material.appbar.AppBarLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:visibility="@{vm.uiState.onPreview ? View.VISIBLE : View.GONE}">
+                    android:visibility="@{vm.uiState.isPreviewFragmentShowing ? View.VISIBLE : View.GONE}">
 
                     <com.google.android.material.appbar.MaterialToolbar
                         android:id="@+id/topAppBar"
@@ -85,13 +85,13 @@
                     app:behavior_fitToContents="false"
                     app:behavior_peekHeight="0dp"
                     app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
-                    draggable="@{!vm.uiState.onPreview}">
+                    draggable="@{!vm.uiState.isPreviewFragmentShowing}">
 
                     <com.google.android.material.bottomsheet.BottomSheetDragHandleView
                         android:id="@+id/drag_handle"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:visibility="@{vm.uiState.onPreview ? View.GONE : View.VISIBLE}" />
+                        android:visibility="@{vm.uiState.isPreviewFragmentShowing ? View.GONE : View.VISIBLE}" />
 
                     <androidx.fragment.app.FragmentContainerView
                         android:id="@+id/fcv"
@@ -113,7 +113,7 @@
                     android:layout_gravity="top"
                     app:layout_anchorGravity="end"
                     android:contentDescription="@string/activity_main_fab_content_description"
-                    android:visibility="@{vm.uiState.onPreview ? View.GONE : View.VISIBLE}"  />
+                    android:visibility="@{vm.uiState.isPreviewFragmentShowing ? View.GONE : View.VISIBLE}"  />
 
             </androidx.coordinatorlayout.widget.CoordinatorLayout>
 

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -54,7 +54,7 @@
                 <com.google.android.material.appbar.AppBarLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:visibility="@{vm.uiState.onPreview ? View.VISIBLE : View.GONE}" >
+                    android:visibility="@{vm.uiState.onPreview ? View.VISIBLE : View.GONE}">
 
                     <com.google.android.material.appbar.MaterialToolbar
                         android:id="@+id/topAppBar"
@@ -64,7 +64,9 @@
                         app:title="@string/app_name"
                         app:titleCentered="true"
                         app:menu="@menu/preview_app_bar_menu"
-                        app:navigationIcon="@drawable/icon_arrow_back" />
+                        app:navigationIcon="@drawable/icon_arrow_back"
+                        navigation_icon_click="@{vm.appbarBackIconClicked}"
+                        menu_item_click="@{vm.appbarCloseIconClicked}"/>
 
                 </com.google.android.material.appbar.AppBarLayout>
 

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -7,6 +7,8 @@
         <variable
             name="vm"
             type="com.boostcampwm2023.snappoint.presentation.main.MainViewModel" />
+
+        <import type="android.view.View" />
     </data>
 
     <androidx.drawerlayout.widget.DrawerLayout
@@ -43,10 +45,28 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:hint="@string/activity_main_sb_hint"
+                    android:visibility="@{vm.uiState.onPreview ? View.GONE : View.VISIBLE}"
                     drawer_icon_click= "@{() -> vm.drawerIconClicked()}"
                     app:elevation="6dp"
                     app:navigationIcon="@drawable/icon_drawer"
                     app:menu="@menu/search_view_menu"/>
+
+                <com.google.android.material.appbar.AppBarLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:visibility="@{vm.uiState.onPreview ? View.VISIBLE : View.GONE}" >
+
+                    <com.google.android.material.appbar.MaterialToolbar
+                        android:id="@+id/topAppBar"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:minHeight="?attr/actionBarSize"
+                        app:title="@string/app_name"
+                        app:titleCentered="true"
+                        app:menu="@menu/preview_app_bar_menu"
+                        app:navigationIcon="@drawable/icon_arrow_back" />
+
+                </com.google.android.material.appbar.AppBarLayout>
 
                 <com.google.android.material.search.SearchView
                     android:layout_width="match_parent"
@@ -62,12 +82,14 @@
                     android:orientation="vertical"
                     app:behavior_fitToContents="false"
                     app:behavior_peekHeight="0dp"
-                    app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
+                    app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
+                    draggable="@{!vm.uiState.onPreview}">
 
                     <com.google.android.material.bottomsheet.BottomSheetDragHandleView
                         android:id="@+id/drag_handle"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content" />
+                        android:layout_height="wrap_content"
+                        android:visibility="@{vm.uiState.onPreview ? View.GONE : View.VISIBLE}" />
 
                     <androidx.fragment.app.FragmentContainerView
                         android:id="@+id/fcv"
@@ -88,7 +110,8 @@
                     app:useCompatPadding="true"
                     android:layout_gravity="top"
                     app:layout_anchorGravity="end"
-                    android:contentDescription="@string/activity_main_fab_content_description" />
+                    android:contentDescription="@string/activity_main_fab_content_description"
+                    android:visibility="@{vm.uiState.onPreview ? View.GONE : View.VISIBLE}"  />
 
             </androidx.coordinatorlayout.widget.CoordinatorLayout>
 

--- a/android/app/src/main/res/layout/fragment_preview.xml
+++ b/android/app/src/main/res/layout/fragment_preview.xml
@@ -22,6 +22,7 @@
             android:layout_width="40dp"
             android:layout_height="40dp"
             android:layout_marginStart="26dp"
+            android:layout_marginTop="16dp"
             android:foreground="@drawable/ic_launcher_foreground"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
@@ -31,6 +32,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
             android:textSize="16sp"
             android:textStyle="bold"
             android:text="@{vm.uiState.title}"
@@ -54,6 +56,7 @@
             android:layout_width="40dp"
             android:layout_height="40dp"
             android:layout_marginEnd="18dp"
+            android:layout_marginTop="16dp"
             android:foreground="@drawable/icon_arrow_down_left"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
@@ -63,7 +66,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            app:layout_constraintGuide_begin="56dp" />
+            app:layout_constraintGuide_begin="72dp" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rcv_preview"

--- a/android/app/src/main/res/menu/preview_app_bar_menu.xml
+++ b/android/app/src/main/res/menu/preview_app_bar_menu.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/preview_close"
+        android:icon="@drawable/icon_cancel"
+        app:showAsAction="ifRoom"
+        android:title="close" />
+</menu>


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): 화면 UI 그리기 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
- [x] `TopAppbar` UI  구성
- [x] menu 생성
- [x] `뒤로가기`, `닫기` 이벤트 구현

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- **임시로 FAB에 미리보기 화면으로 전달하는 이벤트를 연결했습니다.**
- MainActivity의 `uiState`에 미리보기 화면의 `lifecycle`에 맞게 값을 변경하는 Boolean Type 변수를 추가했습니다.
- 미리보기 화면이 열리면 `검색`, `FAB`가 사라지고 `TopAppbar`가 나타납니다.
- 바텀 시트는 가운데에 고정됩니다.
- BindingAdapter로 `뒤로가기`, `닫기` 이벤트를 연결했습니다.

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
- 분명 `drawer_icon_click`을 보고 따라했는데 빌드 에러가 자꾸 나와서 이벤트를 연결할 때 변수로 연결했습니다. 왜 이럴까요??
```
// 전
navigation_icon_click="@{() -> vm.appbarBackIconClicked()}"

// 후
navigation_icon_click="@{vm.appbarBackIconClicked}"

```
참고: https://stackoverflow.com/questions/67404315/android-databinding-bindingadapter-error-missing-return-statement

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->
- 열기
![3-2-1_열기](https://github.com/boostcampwm2023/and01-SnapPoint/assets/76683420/55df5cc3-d61e-4e7b-aa71-6e8dc7a91081)

- 닫기
![3-2-2_닫기](https://github.com/boostcampwm2023/and01-SnapPoint/assets/76683420/a7fa5519-24c8-47bc-af53-0c2d9a8b49d3)

