### PR TITLE
Feature(#43): 미리보기 화면 마커/경로

### DIFF
--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundEvent.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundEvent.kt
@@ -1,0 +1,5 @@
+package com.boostcampwm2023.snappoint.presentation.around
+
+sealed class AroundEvent {
+    data class ShowSnapPointAndRoute(val index: Int): AroundEvent()
+}

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundFragment.kt
@@ -28,9 +28,20 @@ class AroundFragment : BaseFragment<FragmentAroundBinding>(R.layout.fragment_aro
 
     private fun collectViewModelData() {
         viewLifecycleOwner.lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.RESUMED){
-                mainViewModel.uiState.collect{
-                    aroundViewModel.updatePosts(it.posts)
+            repeatOnLifecycle(Lifecycle.State.RESUMED) {
+                launch {
+                    mainViewModel.uiState.collect {
+                        aroundViewModel.updatePosts(it.posts)
+                    }
+                }
+                launch {
+                    aroundViewModel.event.collect { event ->
+                        when (event) {
+                            is AroundEvent.ShowSnapPointAndRoute -> {
+                                mainViewModel.updateSelected(event.index)
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundUiState.kt
@@ -3,6 +3,7 @@ package com.boostcampwm2023.snappoint.presentation.around
 import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
 
 data class AroundUiState(
-    val posts: List<PostSummaryState> = emptyList()
+    val posts: List<PostSummaryState> = emptyList(),
+    val onPreviewButtonClicked: (Int) -> Unit,
 )
 

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundViewModel.kt
@@ -1,11 +1,14 @@
 package com.boostcampwm2023.snappoint.presentation.around
 
 import androidx.lifecycle.ViewModel
-import com.boostcampwm2023.snappoint.presentation.main.MainUiState
 import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import javax.inject.Inject
@@ -15,9 +18,18 @@ class AroundViewModel @Inject constructor(
 
 ) : ViewModel() {
 
-    private val _uiState: MutableStateFlow<AroundUiState> = MutableStateFlow(AroundUiState())
+    private val _uiState: MutableStateFlow<AroundUiState> = MutableStateFlow(AroundUiState(
+        onPreviewButtonClicked = { index ->
+            previewButtonClicked(index)
+        }
+    ))
     val uiState: StateFlow<AroundUiState> = _uiState.asStateFlow()
 
+    private val _event: MutableSharedFlow<AroundEvent> = MutableSharedFlow(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+    val event: SharedFlow<AroundEvent> = _event.asSharedFlow()
 
     fun updatePosts(posts: List<PostSummaryState>) {
         _uiState.update {
@@ -25,5 +37,9 @@ class AroundViewModel @Inject constructor(
                 posts = posts
             )
         }
+    }
+
+    private fun previewButtonClicked(index: Int) {
+        _event.tryEmit(AroundEvent.ShowSnapPointAndRoute(index))
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/PostItemViewHolder.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/PostItemViewHolder.kt
@@ -10,7 +10,8 @@ import com.boostcampwm2023.snappoint.presentation.util.ExpandButtonToggleAnimati
 
 class PostItemViewHolder(
     private val binding: ItemAroundPostBinding,
-    private val onExpandButtonClicked: (Int) -> Unit
+    private val onExpandButtonClicked: (Int) -> Unit,
+    private val onPreviewButtonClicked: (Int) -> Unit,
 ) : RecyclerView.ViewHolder(binding.root) {
 
 
@@ -26,6 +27,10 @@ class PostItemViewHolder(
                 expandState = expandState.not()
                 toggleLayout(expandState, it, layoutExpanded)
                 onExpandButtonClicked(index)
+            }
+
+            btnPreviewPost.setOnClickListener {
+                onPreviewButtonClicked(index)
             }
         }
     }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/PostListAdapter.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/PostListAdapter.kt
@@ -10,6 +10,7 @@ import com.boostcampwm2023.snappoint.databinding.ItemAroundPostBinding
 import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
 
 class PostListAdapter(
+    private val onPreviewButtonClicked: (Int) -> Unit,
 ) : ListAdapter<PostSummaryState, PostItemViewHolder>(diffUtil) {
 
     private var expandedIndexSet: MutableSet<Int> = mutableSetOf()
@@ -21,7 +22,8 @@ class PostListAdapter(
             onExpandButtonClicked = { index ->
                 if (expandedIndexSet.contains(index)) expandedIndexSet.remove(index)
                 else expandedIndexSet.add(index)
-            }
+            },
+            onPreviewButtonClicked = onPreviewButtonClicked
         )
     }
 
@@ -50,8 +52,8 @@ class PostListAdapter(
     }
 }
 
-@BindingAdapter("posts")
-fun RecyclerView.bindRecyclerViewAdapter(posts: List<PostSummaryState>) {
-    if (adapter == null) adapter = PostListAdapter()
+@BindingAdapter("posts", "onPreviewButtonClick")
+fun RecyclerView.bindRecyclerViewAdapter(posts: List<PostSummaryState>, onPreviewButtonClicked: (Int) -> Unit) {
+    if (adapter == null) adapter = PostListAdapter(onPreviewButtonClicked = onPreviewButtonClicked)
     (adapter as PostListAdapter).submitList(posts)
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.boostcampwm2023.snappoint.presentation.main
 
+import android.graphics.Color
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.lifecycle.Lifecycle
@@ -16,8 +17,11 @@ import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.OnMapReadyCallback
 import com.google.android.gms.maps.SupportMapFragment
+import com.google.android.gms.maps.model.Dash
+import com.google.android.gms.maps.model.Gap
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.MarkerOptions
+import com.google.android.gms.maps.model.PolylineOptions
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
@@ -62,7 +66,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
                 launch {
                     viewModel.uiState.collect{uiState ->
                         if (uiState.selectedIndex > -1) {
-                            drawPins()
+                            drawPinsAndRoutes()
                         } else {
                             updateMarker(uiState.snapPoints)
                         }
@@ -89,27 +93,31 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
         }
     }
 
-    private fun drawPins() {
+    private fun drawPinsAndRoutes() {
         googleMap?.clear()
 
         val index = viewModel.uiState.value.selectedIndex
+        val polyline = PolylineOptions().color(Color.RED).pattern(listOf(Dash(20f), Gap(20f)))
         viewModel.uiState.value.posts[index].postBlocks.forEach { block ->
             when (block) {
                 is PostBlockState.IMAGE -> {
                     googleMap?.addMarker(MarkerOptions()
                         .position(LatLng(block.position.latitude, block.position.longitude))
                     )
+                    polyline.add(LatLng(block.position.latitude, block.position.longitude))
                 }
 
                 is PostBlockState.VIDEO -> {
                     googleMap?.addMarker(MarkerOptions()
                         .position(LatLng(block.position.latitude, block.position.longitude))
                     )
+                    polyline.add(LatLng(block.position.latitude, block.position.longitude))
                 }
 
                 else -> {}
             }
         }
+        googleMap?.addPolyline(polyline)
     }
 
     private fun initBottomSheetWithNavigation() {

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -8,13 +8,13 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavController
-import androidx.navigation.findNavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.setupWithNavController
 import com.boostcampwm2023.snappoint.R
 import com.boostcampwm2023.snappoint.databinding.ActivityMainBinding
 import com.boostcampwm2023.snappoint.presentation.base.BaseActivity
+import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
 import com.boostcampwm2023.snappoint.presentation.util.addImageMarker
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
@@ -37,8 +37,9 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
     private val viewModel: MainViewModel by viewModels()
     private var googleMap: GoogleMap? = null
 
-    private val navController: NavController =
+    private val navController: NavController by lazy {
         (supportFragmentManager.findFragmentById(R.id.fcv) as NavHostFragment).findNavController()
+    }
 
     private val bottomSheetBehavior: BottomSheetBehavior<LinearLayout> by lazy {
         BottomSheetBehavior.from(binding.bs)

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -61,7 +61,11 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
                 }
                 launch {
                     viewModel.uiState.collect{uiState ->
-                        updateMarker(uiState.snapPoints)
+                        if (uiState.selectedIndex > -1) {
+                            drawPins()
+                        } else {
+                            updateMarker(uiState.snapPoints)
+                        }
                     }
                 }
             }
@@ -81,6 +85,29 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
                         map.addMarker(it)
                     }
                 }
+            }
+        }
+    }
+
+    private fun drawPins() {
+        googleMap?.clear()
+
+        val index = viewModel.uiState.value.selectedIndex
+        viewModel.uiState.value.posts[index].postBlocks.forEach { block ->
+            when (block) {
+                is PostBlockState.IMAGE -> {
+                    googleMap?.addMarker(MarkerOptions()
+                        .position(LatLng(block.position.latitude, block.position.longitude))
+                    )
+                }
+
+                is PostBlockState.VIDEO -> {
+                    googleMap?.addMarker(MarkerOptions()
+                        .position(LatLng(block.position.latitude, block.position.longitude))
+                    )
+                }
+
+                else -> {}
             }
         }
     }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainUiState.kt
@@ -6,6 +6,7 @@ import com.google.android.gms.maps.model.MarkerOptions
 data class MainUiState(
     val posts: List<PostSummaryState> = emptyList(),
     val snapPoints: List<SnapPointState> = emptyList(),
+    val selectedIndex: Int = -1,
 )
 
 data class SnapPointState(

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainUiState.kt
@@ -6,7 +6,7 @@ import com.google.android.gms.maps.model.MarkerOptions
 data class MainUiState(
     val posts: List<PostSummaryState> = emptyList(),
     val snapPoints: List<SnapPointState> = emptyList(),
-    val isPreviewFragmentShowing: Boolean = false
+    val isPreviewFragmentShowing: Boolean = false,
     val selectedIndex: Int = -1,
 )
 

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
@@ -44,6 +44,12 @@ class MainViewModel @Inject constructor(
         loadPosts()
     }
 
+    fun updateSelected(index: Int) {
+        _uiState.update {
+            it.copy(selectedIndex = index)
+        }
+    }
+
     private fun loadPosts() {
         _uiState.update {
             MainUiState(
@@ -79,7 +85,8 @@ class MainViewModel @Inject constructor(
                                 content = "ㅎㅇ염"
                             ),
                         )
-                    ),PostSummaryState(
+                    ),
+                    PostSummaryState(
                         title = "여기좋아용",
                         author = "안언수",
                         timeStamp = "678",
@@ -93,6 +100,34 @@ class MainViewModel @Inject constructor(
                                 description = "이것은 악어~",
                                 address = "제일 좋아하는 동물이에용"
                             )
+                        )
+                    ),
+                    PostSummaryState(
+                        title = "마커 테스트",
+                        author = "TEST",
+                        timeStamp = "1",
+                        postBlocks = listOf(
+                            PostBlockState.STRING(
+                                content = "123"
+                            ),
+                            PostBlockState.IMAGE(
+                                content = "https://i.namu.wiki/i/Nvsy3_i1lyInOB79UBbcDeR6MocJ4C8TBN8NjepPwqTnojCbb3Xwge9gQXfAGgW74ZA3c3i16odhBLE0bSwgFA.webp",
+                                position = PositionState(9.9, 10.1),
+                                description = "test",
+                                address = "address"
+                            ),
+                            PostBlockState.IMAGE(
+                                content = "https://i.namu.wiki/i/Nvsy3_i1lyInOB79UBbcDeR6MocJ4C8TBN8NjepPwqTnojCbb3Xwge9gQXfAGgW74ZA3c3i16odhBLE0bSwgFA.webp",
+                                position = PositionState(9.6, 9.7),
+                                description = "test",
+                                address = "address"
+                            ),
+                            PostBlockState.IMAGE(
+                                content = "https://i.namu.wiki/i/Nvsy3_i1lyInOB79UBbcDeR6MocJ4C8TBN8NjepPwqTnojCbb3Xwge9gQXfAGgW74ZA3c3i16odhBLE0bSwgFA.webp",
+                                position = PositionState(10.3, 10.5),
+                                description = "test",
+                                address = "address"
+                            ),
                         )
                     ),
                 )

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
@@ -5,8 +5,6 @@ import com.boostcampwm2023.snappoint.data.repository.PostRepository
 import com.boostcampwm2023.snappoint.presentation.model.PositionState
 import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
 import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
-import com.google.android.gms.maps.GoogleMapOptions
-import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.MarkerOptions
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.BufferOverflow
@@ -99,7 +97,13 @@ class MainViewModel @Inject constructor(
                                 position = PositionState(10.4, 10.3),
                                 description = "이것은 악어~",
                                 address = "제일 좋아하는 동물이에용"
-                            )
+                            ),
+                            PostBlockState.IMAGE(
+                                content = "https://i.namu.wiki/i/Nvsy3_i1lyInOB79UBbcDeR6MocJ4C8TBN8NjepPwqTnojCbb3Xwge9gQXfAGgW74ZA3c3i16odhBLE0bSwgFA.webp",
+                                position = PositionState(10.8, 9.8),
+                                description = "이것은 악어~",
+                                address = "제일 좋아하는 동물이에용"
+                            ),
                         )
                     ),
                     PostSummaryState(
@@ -112,13 +116,13 @@ class MainViewModel @Inject constructor(
                             ),
                             PostBlockState.IMAGE(
                                 content = "https://i.namu.wiki/i/Nvsy3_i1lyInOB79UBbcDeR6MocJ4C8TBN8NjepPwqTnojCbb3Xwge9gQXfAGgW74ZA3c3i16odhBLE0bSwgFA.webp",
-                                position = PositionState(9.9, 10.1),
+                                position = PositionState(10.0, 9.7),
                                 description = "test",
                                 address = "address"
                             ),
                             PostBlockState.IMAGE(
                                 content = "https://i.namu.wiki/i/Nvsy3_i1lyInOB79UBbcDeR6MocJ4C8TBN8NjepPwqTnojCbb3Xwge9gQXfAGgW74ZA3c3i16odhBLE0bSwgFA.webp",
-                                position = PositionState(9.6, 9.7),
+                                position = PositionState(9.9, 10.1),
                                 description = "test",
                                 address = "address"
                             ),

--- a/android/app/src/main/res/layout/fragment_around.xml
+++ b/android/app/src/main/res/layout/fragment_around.xml
@@ -35,6 +35,7 @@
             android:padding="20dp"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             posts="@{vm.uiState.posts}"
+            onPreviewButtonClick="@{vm.uiState.onPreviewButtonClicked}"
             tools:listitem="@layout/item_around_post" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 작업 개요
- [x] 게시글 목록에서 미리보기 버튼 클릭 시 해당 게시글의 마커를 지도에 표시
- [x] 미리보기 버튼 클릭 시 마커를 잇는 경로도 표시

## 작업 사항
- 게시글 목록에서 미리보기 버튼 클릭 시 해당 게시글의 인덱스를 MainViewModel의 UiState에 전달하고, MainActivity에선 UiState의 selectedIndex 값이 -1보다 크다면 게시글이 선택된 것으로 간주하고 해당 게시글의 마커들을 모두 지도에 그리도록 구현하였습니다.
- 마커를 생성할 때 PolylineOptions()를 통해 마커 사이를 잇는 선을 함께 생성해서 지도에 표시해주도록 구현하였습니다.

## 스크린샷(필수 X)
<image src=https://github.com/boostcampwm2023/and01-SnapPoint/assets/85796984/350722a7-28a9-4cb1-afa9-d372e4931d5d width=270 height=600>
