### PR TITLE
Feature(#43): 미리보기 화면으로 이동

### DIFF
--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundFragment.kt
@@ -39,6 +39,7 @@ class AroundFragment : BaseFragment<FragmentAroundBinding>(R.layout.fragment_aro
                         when (event) {
                             is AroundEvent.ShowSnapPointAndRoute -> {
                                 mainViewModel.updateSelected(event.index)
+                                mainViewModel.previewButtonClicked(event.index)
                             }
                         }
                     }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -2,8 +2,11 @@ package com.boostcampwm2023.snappoint.presentation.main
 
 import android.graphics.Color
 import android.os.Bundle
+import android.view.View
 import android.widget.LinearLayout
 import androidx.activity.viewModels
+import androidx.core.view.doOnLayout
+import androidx.core.view.marginTop
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -26,6 +29,7 @@ import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.MarkerOptions
 import com.google.android.gms.maps.model.PolylineOptions
 import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCallback
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -147,7 +151,18 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
 
     private fun initBottomSheetWithNavigation() {
         binding.bnv.setupWithNavController(navController)
+        bottomSheetBehavior.halfExpandedRatio = 0.45f
         bottomSheetBehavior.state = BottomSheetBehavior.STATE_HALF_EXPANDED
+        binding.sb.doOnLayout { bottomSheetBehavior.expandedOffset = binding.sb.height + binding.sb.marginTop * 2 }
+        bottomSheetBehavior.addBottomSheetCallback(object : BottomSheetCallback() {
+            override fun onStateChanged(bottomSheet: View, state: Int) {
+                viewModel.onBottomSheetChanged(state == BottomSheetBehavior.STATE_EXPANDED)
+            }
+
+            override fun onSlide(p0: View, p1: Float) {
+
+            }
+        })
 
         binding.bnv.setOnItemReselectedListener { _ ->
             when (bottomSheetBehavior.state) {

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -2,7 +2,6 @@ package com.boostcampwm2023.snappoint.presentation.main
 
 import android.graphics.Color
 import android.os.Bundle
-import android.util.Log
 import android.widget.LinearLayout
 import androidx.activity.viewModels
 import androidx.lifecycle.Lifecycle

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -2,6 +2,7 @@ package com.boostcampwm2023.snappoint.presentation.main
 
 import android.graphics.Color
 import android.os.Bundle
+import android.util.Log
 import android.widget.LinearLayout
 import androidx.activity.viewModels
 import androidx.lifecycle.Lifecycle
@@ -56,8 +57,6 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
 
         collectViewModelData()
 
-        // FAB 구현할 때 삭제해 주세요!!
-        setFabClickEvent()
     }
 
     private fun initMapApi() {
@@ -81,6 +80,9 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
                             MainActivityEvent.NavigateClose -> {
                                 navController.popBackStack()
                                 bottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
+                            }
+                            is MainActivityEvent.NavigatePreview -> {
+                                openPreviewFragment()
                             }
                         }
                     }
@@ -154,12 +156,6 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
                 BottomSheetBehavior.STATE_EXPANDED -> { bottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED }
                 else -> { bottomSheetBehavior.state = BottomSheetBehavior.STATE_HALF_EXPANDED }
             }
-        }
-    }
-
-    private fun setFabClickEvent() {
-        binding.fab.setOnClickListener {
-            openPreviewFragment()
         }
     }
 

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivityEvent.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivityEvent.kt
@@ -4,4 +4,5 @@ sealed class MainActivityEvent {
     data object OpenDrawer: MainActivityEvent()
     data object NavigatePrev: MainActivityEvent()
     data object NavigateClose: MainActivityEvent()
+    data class NavigatePreview(val index: Int): MainActivityEvent()
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainUiState.kt
@@ -8,6 +8,7 @@ data class MainUiState(
     val snapPoints: List<SnapPointState> = emptyList(),
     val isPreviewFragmentShowing: Boolean = false,
     val selectedIndex: Int = -1,
+    val isBottomSheetExpanded: Boolean = false,
 )
 
 data class SnapPointState(

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
@@ -188,4 +188,10 @@ class MainViewModel @Inject constructor(
             )
         }
     }
+
+    fun onBottomSheetChanged(expanded: Boolean) {
+        _uiState.update {
+            it.copy(isBottomSheetExpanded = expanded)
+        }
+    }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
@@ -189,9 +189,9 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    fun onBottomSheetChanged(expanded: Boolean) {
+    fun onBottomSheetChanged(isExpanded: Boolean) {
         _uiState.update {
-            it.copy(isBottomSheetExpanded = expanded)
+            it.copy(isBottomSheetExpanded = isExpanded)
         }
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
@@ -183,7 +183,8 @@ class MainViewModel @Inject constructor(
     fun onPreviewFragmentClosing() {
         _uiState.update {
             it.copy(
-                isPreviewFragmentShowing = false
+                isPreviewFragmentShowing = false,
+                selectedIndex = -1
             )
         }
     }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
@@ -47,6 +47,10 @@ class MainViewModel @Inject constructor(
         _event.tryEmit(MainActivityEvent.NavigateClose)
     }
 
+    fun previewButtonClicked(index: Int) {
+        _event.tryEmit(MainActivityEvent.NavigatePreview(index))
+    }
+
     init{
         loadPosts()
     }

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -82,6 +82,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:orientation="vertical"
+                    android:backgroundTint="@color/surfaceContainerLow"
                     app:behavior_fitToContents="false"
                     app:behavior_peekHeight="0dp"
                     app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
@@ -113,7 +114,7 @@
                     android:layout_gravity="top"
                     app:layout_anchorGravity="end"
                     android:contentDescription="@string/activity_main_fab_content_description"
-                    android:visibility="@{vm.uiState.isPreviewFragmentShowing ? View.GONE : View.VISIBLE}"  />
+                    android:visibility="@{vm.uiState.isPreviewFragmentShowing || vm.uiState.isBottomSheetExpanded ? View.GONE : View.VISIBLE}"  />
 
             </androidx.coordinatorlayout.widget.CoordinatorLayout>
 

--- a/android/app/src/main/res/layout/fragment_around.xml
+++ b/android/app/src/main/res/layout/fragment_around.xml
@@ -14,7 +14,6 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/surfaceContainerLow"
         tools:context=".presentation.around.AroundFragment">
 
         <TextView


### PR DESCRIPTION
## 작업 개요
- [x] 미리보기 화면에서 뒤로가기 또는 닫기 버튼 클릭 시 다시 전체 마커를 지도에 표시
- [x] 미리보기 버튼 클릭 시 미리보기 화면으로 이동

## 작업 사항
- 미리보기 버튼을 클릭하면 이벤트로 해당 게시글의 인덱스를 전달하고 미리보기 화면을 띄우도록 구현하였습니다.
- 미리보기 화면으로 이동할 때 바텀시트의 state를 `HALF_EXPANDED`로 변경하도록 구현하였습니다.
- Preview Fragment가 destroy될 때 MainActivity의 `selectedIndex`를 -1로 바꿔, 다시 전체 마커가 지도에 표시되도록 구현하였습니다.

## 스크린샷(필수 X)
![ezgif com-video-to-gif](https://github.com/boostcampwm2023/and01-SnapPoint/assets/85796984/95f2f2d5-ee31-4eb7-9de6-43e6c3a65ff7)


