### PR TITLE
Feature(#32): 미리보기 화면에서 하단 네비게이션 이벤트 수정

### DIFF
--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundFragment.kt
@@ -1,6 +1,7 @@
 package com.boostcampwm2023.snappoint.presentation.around
 
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
@@ -38,7 +39,6 @@ class AroundFragment : BaseFragment<FragmentAroundBinding>(R.layout.fragment_aro
                     aroundViewModel.event.collect { event ->
                         when (event) {
                             is AroundEvent.ShowSnapPointAndRoute -> {
-                                mainViewModel.updateSelected(event.index)
                                 mainViewModel.previewButtonClicked(event.index)
                             }
                         }
@@ -52,5 +52,24 @@ class AroundFragment : BaseFragment<FragmentAroundBinding>(R.layout.fragment_aro
         with(binding) {
             vm = aroundViewModel
         }
+    }
+
+    override fun onStart() {
+        super.onStart()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        Log.d("LOG", "onStop")
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        Log.d("LOG", "onDestroyView")
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        Log.d("LOG", "onDestroy")
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -36,8 +36,7 @@ import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
-    OnMapReadyCallback
-{
+    OnMapReadyCallback {
     private val viewModel: MainViewModel by viewModels()
     private var googleMap: GoogleMap? = null
 
@@ -61,30 +60,38 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
         collectViewModelData()
 
         setBottomNavigationEvent()
+
+        binding.fab.setOnClickListener {
+            openPreviewFragment()
+        }
     }
 
     private fun initMapApi() {
-        val map: SupportMapFragment = supportFragmentManager.findFragmentById(R.id.fcv_main_map) as SupportMapFragment
+        val map: SupportMapFragment =
+            supportFragmentManager.findFragmentById(R.id.fcv_main_map) as SupportMapFragment
         map.getMapAsync(this)
     }
 
     private fun collectViewModelData() {
         lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.RESUMED){
+            repeatOnLifecycle(Lifecycle.State.RESUMED) {
 
                 launch {
-                    viewModel.event.collect{event ->
-                        when(event){
+                    viewModel.event.collect { event ->
+                        when (event) {
                             MainActivityEvent.OpenDrawer -> {
                                 openDrawer()
                             }
+
                             MainActivityEvent.NavigatePrev -> {
                                 navController.popBackStack()
                             }
+
                             MainActivityEvent.NavigateClose -> {
                                 navController.popBackStack()
                                 bottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
                             }
+
                             is MainActivityEvent.NavigatePreview -> {
                                 openPreviewFragment()
                             }
@@ -92,7 +99,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
                     }
                 }
                 launch {
-                    viewModel.uiState.collect{uiState ->
+                    viewModel.uiState.collect { uiState ->
                         if (uiState.selectedIndex > -1) {
                             drawPinsAndRoutes()
                         } else {
@@ -106,7 +113,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
 
     private fun updateMarker(snapPoints: List<SnapPointState>) {
         lifecycleScope.launch {
-            while(googleMap == null){
+            while (googleMap == null) {
                 delay(1000)
             }
             googleMap?.let { map ->
@@ -116,7 +123,8 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
                         map.addImageMarker(
                             context = this@MainActivity,
                             markerOptions = markerOptions,
-                            uri = "https://t3.gstatic.com/licensed-image?q=tbn:ANd9GcRoT6NNDUONDQmlthWrqIi_frTjsjQT4UZtsJsuxqxLiaFGNl5s3_pBIVxS6-VsFUP_")
+                            uri = "https://t3.gstatic.com/licensed-image?q=tbn:ANd9GcRoT6NNDUONDQmlthWrqIi_frTjsjQT4UZtsJsuxqxLiaFGNl5s3_pBIVxS6-VsFUP_"
+                        )
                     }
                 }
             }
@@ -131,15 +139,17 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
         viewModel.uiState.value.posts[index].postBlocks.forEach { block ->
             when (block) {
                 is PostBlockState.IMAGE -> {
-                    googleMap?.addMarker(MarkerOptions()
-                        .position(LatLng(block.position.latitude, block.position.longitude))
+                    googleMap?.addMarker(
+                        MarkerOptions()
+                            .position(LatLng(block.position.latitude, block.position.longitude))
                     )
                     polyline.add(LatLng(block.position.latitude, block.position.longitude))
                 }
 
                 is PostBlockState.VIDEO -> {
-                    googleMap?.addMarker(MarkerOptions()
-                        .position(LatLng(block.position.latitude, block.position.longitude))
+                    googleMap?.addMarker(
+                        MarkerOptions()
+                            .position(LatLng(block.position.latitude, block.position.longitude))
                     )
                     polyline.add(LatLng(block.position.latitude, block.position.longitude))
                 }
@@ -154,7 +164,9 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
         binding.bnv.setupWithNavController(navController)
         bottomSheetBehavior.halfExpandedRatio = 0.45f
         bottomSheetBehavior.state = BottomSheetBehavior.STATE_HALF_EXPANDED
-        binding.sb.doOnLayout { bottomSheetBehavior.expandedOffset = binding.sb.height + binding.sb.marginTop * 2 }
+        binding.sb.doOnLayout {
+            bottomSheetBehavior.expandedOffset = binding.sb.height + binding.sb.marginTop * 2
+        }
         bottomSheetBehavior.addBottomSheetCallback(object : BottomSheetCallback() {
             override fun onStateChanged(bottomSheet: View, state: Int) {
                 viewModel.onBottomSheetChanged(state == BottomSheetBehavior.STATE_EXPANDED)
@@ -180,36 +192,14 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
 
     private fun setBottomNavigationEvent() {
         binding.bnv.setOnItemSelectedListener { menuItem ->
-            when(menuItem.itemId) {
-                R.id.aroundFragment -> {
-                    navController.popBackStack()
-                    navController.navigate(R.id.aroundFragment)
-                    true
-                }
-                R.id.subscriptionFragment -> {
-                    navController.popBackStack()
-                    navController.navigate(R.id.subscriptionFragment)
-                    true
-                }
-                R.id.popularPostFragment -> {
-                    navController.popBackStack()
-                    navController.navigate(R.id.popularPostFragment)
-                    true
-                }
-                R.id.settingFragment -> {
-                    navController.popBackStack()
-                    navController.navigate(R.id.settingFragment)
-                    true
-                }
-                else -> false
-            }
+            navController.popBackStack()
+            navController.navigate(menuItem.itemId)
+            true
         }
     }
 
     private fun openPreviewFragment() {
         bottomSheetBehavior.state = BottomSheetBehavior.STATE_HALF_EXPANDED
-        navController.popBackStack()
-        navController.navigate(R.id.aroundFragment)
         navController.navigate(R.id.previewFragment)
     }
 
@@ -218,7 +208,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
     }
 
     private fun initBinding() {
-        with(binding){
+        with(binding) {
             vm = viewModel
         }
     }
@@ -226,6 +216,6 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
     override fun onMapReady(googleMap: GoogleMap) {
         this.googleMap = googleMap
 
-        googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(10.0,10.0), 10f))
+        googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(10.0, 10.0), 10f))
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -60,6 +60,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
 
         collectViewModelData()
 
+        setBottomNavigationEvent()
     }
 
     private fun initMapApi() {
@@ -165,17 +166,51 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
         })
 
         binding.bnv.setOnItemReselectedListener { _ ->
-            when (bottomSheetBehavior.state) {
-                BottomSheetBehavior.STATE_HALF_EXPANDED -> { bottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED }
-                BottomSheetBehavior.STATE_EXPANDED -> { bottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED }
-                else -> { bottomSheetBehavior.state = BottomSheetBehavior.STATE_HALF_EXPANDED }
+            if (viewModel.uiState.value.isPreviewFragmentShowing) {
+                return@setOnItemReselectedListener
+            }
+
+            bottomSheetBehavior.state = when (bottomSheetBehavior.state) {
+                BottomSheetBehavior.STATE_HALF_EXPANDED -> BottomSheetBehavior.STATE_EXPANDED
+                BottomSheetBehavior.STATE_EXPANDED -> BottomSheetBehavior.STATE_COLLAPSED
+                else -> BottomSheetBehavior.STATE_HALF_EXPANDED
+            }
+        }
+    }
+
+    private fun setBottomNavigationEvent() {
+        binding.bnv.setOnItemSelectedListener { menuItem ->
+            when(menuItem.itemId) {
+                R.id.aroundFragment -> {
+                    navController.popBackStack()
+                    navController.navigate(R.id.aroundFragment)
+                    true
+                }
+                R.id.subscriptionFragment -> {
+                    navController.popBackStack()
+                    navController.navigate(R.id.subscriptionFragment)
+                    true
+                }
+                R.id.popularPostFragment -> {
+                    navController.popBackStack()
+                    navController.navigate(R.id.popularPostFragment)
+                    true
+                }
+                R.id.settingFragment -> {
+                    navController.popBackStack()
+                    navController.navigate(R.id.settingFragment)
+                    true
+                }
+                else -> false
             }
         }
     }
 
     private fun openPreviewFragment() {
         bottomSheetBehavior.state = BottomSheetBehavior.STATE_HALF_EXPANDED
-        navController.navigate(R.id.action_aroundFragment_to_previewFragment)
+        navController.popBackStack()
+        navController.navigate(R.id.aroundFragment)
+        navController.navigate(R.id.previewFragment)
     }
 
     private fun openDrawer() {

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
@@ -32,33 +32,8 @@ class MainViewModel @Inject constructor(
     )
     val event: SharedFlow<MainActivityEvent> = _event.asSharedFlow()
 
-
-
-
-    fun drawerIconClicked() {
-        _event.tryEmit(MainActivityEvent.OpenDrawer)
-    }
-
-    fun appbarBackIconClicked() {
-        _event.tryEmit(MainActivityEvent.NavigatePrev)
-    }
-
-    fun appbarCloseIconClicked() {
-        _event.tryEmit(MainActivityEvent.NavigateClose)
-    }
-
-    fun previewButtonClicked(index: Int) {
-        _event.tryEmit(MainActivityEvent.NavigatePreview(index))
-    }
-
-    init{
+    init {
         loadPosts()
-    }
-
-    fun updateSelected(index: Int) {
-        _uiState.update {
-            it.copy(selectedIndex = index)
-        }
     }
 
     private fun loadPosts() {
@@ -158,18 +133,39 @@ class MainViewModel @Inject constructor(
             it.copy(
                 snapPoints =
                 _uiState.value.posts.mapIndexed { index, postSummaryState ->
-                        SnapPointState(
-                            index = index,
-                            markerOptions = postSummaryState.postBlocks.filterIsInstance<PostBlockState.IMAGE>().map {
-                                    MarkerOptions().apply {
-                                        position(it.position.asLatLng())
-                                    }
+                    SnapPointState(
+                        index = index,
+                        markerOptions = postSummaryState.postBlocks.filterIsInstance<PostBlockState.IMAGE>().map {
+                            MarkerOptions().apply {
+                                position(it.position.asLatLng())
                             }
-                        )
+                        }
+                    )
                 }
             )
         }
 
+    }
+
+    fun drawerIconClicked() {
+        _event.tryEmit(MainActivityEvent.OpenDrawer)
+    }
+
+    fun appbarBackIconClicked() {
+        _event.tryEmit(MainActivityEvent.NavigatePrev)
+    }
+
+    fun appbarCloseIconClicked() {
+        _event.tryEmit(MainActivityEvent.NavigateClose)
+    }
+
+
+
+    fun previewButtonClicked(index: Int) {
+        _uiState.update {
+            it.copy(selectedIndex = index)
+        }
+        _event.tryEmit(MainActivityEvent.NavigatePreview(index))
     }
 
     fun onPreviewFragmentShowing() {

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/mainbindingAdapter.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/mainbindingAdapter.kt
@@ -32,9 +32,15 @@ fun navigationIconClick(view: MaterialToolbar, event: () -> Unit) {
 @BindingAdapter("menu_item_click")
 fun menuItemClick(view: MaterialToolbar, event: () -> Unit) {
     view.setOnMenuItemClickListener {
-        when(it.itemId) {
-            R.id.preview_close -> event.invoke()
+        return@setOnMenuItemClickListener when (it.itemId) {
+            R.id.preview_close -> {
+                event.invoke()
+                true
+            }
+
+            else -> {
+                true
+            }
         }
-        true
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/preview/PreviewFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/preview/PreviewFragment.kt
@@ -14,8 +14,10 @@ import com.boostcampwm2023.snappoint.databinding.FragmentPreviewBinding
 import com.boostcampwm2023.snappoint.presentation.base.BaseFragment
 import com.boostcampwm2023.snappoint.presentation.main.MainViewModel
 import com.google.android.material.carousel.CarouselSnapHelper
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
+@AndroidEntryPoint
 class PreviewFragment : BaseFragment<FragmentPreviewBinding>(R.layout.fragment_preview) {
 
     private val previewViewModel: PreviewViewModel by viewModels()
@@ -28,18 +30,14 @@ class PreviewFragment : BaseFragment<FragmentPreviewBinding>(R.layout.fragment_p
         super.onCreate(savedInstanceState)
         mainViewModel.onPreviewFragmentShowing()
     }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         initBinding()
         collectViewModelData()
 
-        binding.rcvPreview.setOnScrollChangeListener { _, _, _, _, _ ->
-            Log.d(
-                "LOG",
-                "IDX: ${layoutManager.getPosition(snapHelper.findSnapView(layoutManager)!!)}"
-            )
-        }
+        setScrollEvent()
     }
 
     override fun onDestroy() {
@@ -61,6 +59,15 @@ class PreviewFragment : BaseFragment<FragmentPreviewBinding>(R.layout.fragment_p
                     previewViewModel.updatePost(it.posts[0])
                 }
             }
+        }
+    }
+
+    private fun setScrollEvent() {
+        binding.rcvPreview.setOnScrollChangeListener { _, _, _, _, _ ->
+            Log.d(
+                "LOG",
+                "IDX: ${layoutManager.getPosition(snapHelper.findSnapView(layoutManager)!!)}"
+            )
         }
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/preview/PreviewFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/preview/PreviewFragment.kt
@@ -42,7 +42,14 @@ class PreviewFragment : BaseFragment<FragmentPreviewBinding>(R.layout.fragment_p
 
     override fun onDestroy() {
         super.onDestroy()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        Log.d("LOG", "onDestroyView: asd")
         mainViewModel.onPreviewFragmentClosing()
+        Log.d("LOG", "onDestroyView: asdasd")
+
     }
 
     private fun initBinding() {

--- a/android/app/src/main/res/navigation/nav_bnv.xml
+++ b/android/app/src/main/res/navigation/nav_bnv.xml
@@ -8,11 +8,7 @@
     <fragment
         android:id="@+id/aroundFragment"
         android:name="com.boostcampwm2023.snappoint.presentation.around.AroundFragment"
-        android:label="AroundFragment" >
-        <action
-            android:id="@+id/action_aroundFragment_to_previewFragment"
-            app:destination="@id/previewFragment" />
-    </fragment>
+        android:label="AroundFragment" />
     <fragment
         android:id="@+id/popularPostFragment"
         android:name="com.boostcampwm2023.snappoint.presentation.popularpost.PopularPostFragment"


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): 화면 UI 그리기 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
- [x] 미리보기 화면에서 탭 변경시 backstack에서 제거

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- 하단 네비게이션 클릭 이벤트 구현
- 네비게이션 이동 시 이전화면은 `backstack`에서 제거
- 코드 줄 바꿈 개선

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
- lifecycle 콜백 내부에서 해결하려다 보니 잘 진행이 안 됐습니다.
  - `navController.navigate()`함수로 종료되지 않은(onDestroy가 호출되지 않은) fragment를 불러오려 하면 아무런 행동을 하지 않습니다.
  - `AroundFragment`는 다른 화면으로 넘어가면 `onStop`까지만 진행이 돼서, `onStop` 내부에서 `backstack`삭제를 시도했는데 런타임오류로 잘 되지 않았습니다.
  - 그래서 `Bottom Navigation View`의 이벤트를 오버라이딩해서 직접 구현한 다음 메인 액티비티에서 Fragment간의 이동을 관리하도록 수정했습니다.

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->
- 탭 변경하는 부분 스크린샷
![GIFS2](https://github.com/boostcampwm2023/and01-SnapPoint/assets/76683420/e9b9da16-2583-4f7e-ac77-f82843946d83)
