### PR TITLE
Feature(#10, #11): 단일 핀 선택 및 관련 게시물 경로 표시

### DIFF
--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundFragment.kt
@@ -54,22 +54,4 @@ class AroundFragment : BaseFragment<FragmentAroundBinding>(R.layout.fragment_aro
         }
     }
 
-    override fun onStart() {
-        super.onStart()
-    }
-
-    override fun onStop() {
-        super.onStop()
-        Log.d("LOG", "onStop")
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        Log.d("LOG", "onDestroyView")
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        Log.d("LOG", "onDestroy")
-    }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -120,11 +120,12 @@ class MainActivity :
             while (googleMap == null) {
                 delay(100)
             }
+            val selectedIndex = viewModel.uiState.value.selectedIndex
             googleMap?.let { map ->
                 map.clear()
                 snapPoints.forEachIndexed { postIndex, snapPointState ->
-                    if(postIndex == viewModel.uiState.value.selectedIndex){
-                        drawPinsAndRoutes()
+                    if(postIndex == selectedIndex){
+                        drawPinsAndRoutes(selectedIndex)
                     }
                     snapPointState.markerOptions.forEachIndexed { snapPointIndex, markerOptions ->
                         val focused =
@@ -142,10 +143,9 @@ class MainActivity :
         }
     }
 
-    private fun drawPinsAndRoutes() {
-        val index = viewModel.uiState.value.selectedIndex
-        val polylineOptions = PolylineOptions()
-        val list = viewModel.uiState.value.posts[index].postBlocks.filterNot { it is PostBlockState.STRING }.map{ block ->
+    private fun drawPinsAndRoutes(postIndex: Int) {
+        val polylineOptions = PolylineOptions().color(Color.BLACK).width(3.pxFloat()).pattern(listOf(Dash(20f), Gap(20f)))
+        val positionList = viewModel.uiState.value.posts[postIndex].postBlocks.filterNot { it is PostBlockState.STRING }.map{ block ->
             when (block) {
                 is PostBlockState.IMAGE -> {
                     LatLng(block.position.latitude, block.position.longitude)
@@ -158,10 +158,8 @@ class MainActivity :
                 is PostBlockState.STRING -> TODO()
             }
         }
-        polylineOptions.color(Color.BLACK).width(3.pxFloat()).pattern(listOf(Dash(20f), Gap(20f)))
-        polylineOptions.addAll(list)
-        Log.d("TAG", "drawPinsAndRoutes: ${polylineOptions.points}")
-        val polyline = googleMap?.addPolyline(polylineOptions)
+        polylineOptions.addAll(positionList)
+        googleMap?.addPolyline(polylineOptions)
     }
 
     private fun initBottomSheetWithNavigation() {

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -2,6 +2,7 @@ package com.boostcampwm2023.snappoint.presentation.main
 
 import android.graphics.Color
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import android.widget.LinearLayout
 import androidx.activity.viewModels
@@ -18,15 +19,17 @@ import com.boostcampwm2023.snappoint.R
 import com.boostcampwm2023.snappoint.databinding.ActivityMainBinding
 import com.boostcampwm2023.snappoint.presentation.base.BaseActivity
 import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
+import com.boostcampwm2023.snappoint.presentation.model.SnapPointTag
 import com.boostcampwm2023.snappoint.presentation.util.addImageMarker
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
+import com.google.android.gms.maps.GoogleMap.OnMarkerClickListener
 import com.google.android.gms.maps.OnMapReadyCallback
 import com.google.android.gms.maps.SupportMapFragment
 import com.google.android.gms.maps.model.Dash
 import com.google.android.gms.maps.model.Gap
 import com.google.android.gms.maps.model.LatLng
-import com.google.android.gms.maps.model.MarkerOptions
+import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.PolylineOptions
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCallback
@@ -35,8 +38,11 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
-class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
-    OnMapReadyCallback {
+class MainActivity :
+    BaseActivity<ActivityMainBinding>(R.layout.activity_main),
+    OnMapReadyCallback,
+    OnMarkerClickListener
+{
     private val viewModel: MainViewModel by viewModels()
     private var googleMap: GoogleMap? = null
 
@@ -55,7 +61,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
 
         initBottomSheetWithNavigation()
 
-        initMapApi()
+        initMapFragment()
 
         collectViewModelData()
 
@@ -66,10 +72,11 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
         }
     }
 
-    private fun initMapApi() {
+    private fun initMapFragment() {
         val map: SupportMapFragment =
             supportFragmentManager.findFragmentById(R.id.fcv_main_map) as SupportMapFragment
         map.getMapAsync(this)
+
     }
 
     private fun collectViewModelData() {
@@ -100,10 +107,9 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
                 }
                 launch {
                     viewModel.uiState.collect { uiState ->
+                        updateMarker(uiState.snapPoints)
                         if (uiState.selectedIndex > -1) {
                             drawPinsAndRoutes()
-                        } else {
-                            updateMarker(uiState.snapPoints)
                         }
                     }
                 }
@@ -114,16 +120,20 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
     private fun updateMarker(snapPoints: List<SnapPointState>) {
         lifecycleScope.launch {
             while (googleMap == null) {
-                delay(1000)
+                delay(100)
             }
             googleMap?.let { map ->
                 map.clear()
-                snapPoints.forEach {
-                    it.markerOptions.forEach { markerOptions ->
+                snapPoints.forEachIndexed { postIndex, snapPointState ->
+                    snapPointState.markerOptions.forEachIndexed { snapPointIndex, markerOptions ->
+                        val focused =
+                            (postIndex == viewModel.uiState.value.selectedIndex) && (snapPointIndex == viewModel.uiState.value.focusedIndex)
                         map.addImageMarker(
                             context = this@MainActivity,
                             markerOptions = markerOptions,
-                            uri = "https://t3.gstatic.com/licensed-image?q=tbn:ANd9GcRoT6NNDUONDQmlthWrqIi_frTjsjQT4UZtsJsuxqxLiaFGNl5s3_pBIVxS6-VsFUP_"
+                            uri = "https://t3.gstatic.com/licensed-image?q=tbn:ANd9GcRoT6NNDUONDQmlthWrqIi_frTjsjQT4UZtsJsuxqxLiaFGNl5s3_pBIVxS6-VsFUP_",
+                            tag = SnapPointTag(postIndex = postIndex, snapPointIndex = snapPointIndex),
+                            focused = focused
                         )
                     }
                 }
@@ -132,25 +142,16 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
     }
 
     private fun drawPinsAndRoutes() {
-        googleMap?.clear()
 
         val index = viewModel.uiState.value.selectedIndex
         val polyline = PolylineOptions().color(Color.RED).pattern(listOf(Dash(20f), Gap(20f)))
         viewModel.uiState.value.posts[index].postBlocks.forEach { block ->
             when (block) {
                 is PostBlockState.IMAGE -> {
-                    googleMap?.addMarker(
-                        MarkerOptions()
-                            .position(LatLng(block.position.latitude, block.position.longitude))
-                    )
                     polyline.add(LatLng(block.position.latitude, block.position.longitude))
                 }
 
                 is PostBlockState.VIDEO -> {
-                    googleMap?.addMarker(
-                        MarkerOptions()
-                            .position(LatLng(block.position.latitude, block.position.longitude))
-                    )
                     polyline.add(LatLng(block.position.latitude, block.position.longitude))
                 }
 
@@ -216,6 +217,15 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
     override fun onMapReady(googleMap: GoogleMap) {
         this.googleMap = googleMap
 
+        googleMap.setOnMarkerClickListener(this)
+
         googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(10.0, 10.0), 10f))
+    }
+
+
+    override fun onMarkerClick(marker: Marker): Boolean {
+        Log.d("TAG", "initSnapPointClickListener: $marker")
+        viewModel.onMarkerClicked(marker.tag as SnapPointTag)
+        return true
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -225,7 +225,6 @@ class MainActivity :
 
 
     override fun onMarkerClick(marker: Marker): Boolean {
-        Log.d("TAG", "initSnapPointClickListener: $marker")
         viewModel.onMarkerClicked(marker.tag as SnapPointTag)
         return true
     }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -144,7 +144,7 @@ class MainActivity :
     }
 
     private fun drawPinsAndRoutes(postIndex: Int) {
-        val polylineOptions = PolylineOptions().color(Color.BLACK).width(3.pxFloat()).pattern(listOf(Dash(20f), Gap(20f)))
+        val polylineOptions = PolylineOptions().color(getColor(R.color.error80)).width(3.pxFloat()).pattern(listOf(Dash(20f), Gap(20f)))
         val positionList = viewModel.uiState.value.posts[postIndex].postBlocks.filterNot { it is PostBlockState.STRING }.map{ block ->
             when (block) {
                 is PostBlockState.IMAGE -> {

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainUiState.kt
@@ -6,8 +6,9 @@ import com.google.android.gms.maps.model.MarkerOptions
 data class MainUiState(
     val posts: List<PostSummaryState> = emptyList(),
     val snapPoints: List<SnapPointState> = emptyList(),
-    val isPreviewFragmentShowing: Boolean = false,
     val selectedIndex: Int = -1,
+    val focusedIndex: Int = -1,
+    val isPreviewFragmentShowing: Boolean = false,
     val isBottomSheetExpanded: Boolean = false,
 )
 

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
@@ -1,10 +1,13 @@
 package com.boostcampwm2023.snappoint.presentation.main
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import com.boostcampwm2023.snappoint.data.repository.PostRepository
 import com.boostcampwm2023.snappoint.presentation.model.PositionState
 import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
 import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
+import com.boostcampwm2023.snappoint.presentation.model.SnapPointTag
+import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.MarkerOptions
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.BufferOverflow
@@ -53,15 +56,7 @@ class MainViewModel @Inject constructor(
                                 position = PositionState(10.0, 10.0),
                                 description = "고양이입니다.",
                                 address = "고양이를 발견한 동네"
-                            )
-                        )
-                    ),
-                    PostSummaryState(
-                        title = "놀러갔다온썰푼다",
-                        author = "이정건",
-                        timeStamp = "456",
-                        postBlocks = listOf(
-                            PostBlockState.IMAGE(
+                            ),PostBlockState.IMAGE(
                                 content = "https://pds.joongang.co.kr/news/component/htmlphoto_mmdata/201901/20/28017477-0365-4a43-b546-008b603da621.jpg",
                                 position = PositionState(10.1, 10.1),
                                 description = "강아징입니다.",
@@ -69,15 +64,7 @@ class MainViewModel @Inject constructor(
                             ),
                             PostBlockState.STRING(
                                 content = "ㅎㅇ염"
-                            ),
-                        )
-                    ),
-                    PostSummaryState(
-                        title = "여기좋아용",
-                        author = "안언수",
-                        timeStamp = "678",
-                        postBlocks = listOf(
-                            PostBlockState.STRING(
+                            ),PostBlockState.STRING(
                                 content = "동물원갔다왔슴다 ㅋ"
                             ),
                             PostBlockState.IMAGE(
@@ -162,9 +149,7 @@ class MainViewModel @Inject constructor(
 
 
     fun previewButtonClicked(index: Int) {
-        _uiState.update {
-            it.copy(selectedIndex = index)
-        }
+        updateSelectedIndex(index = index)
         _event.tryEmit(MainActivityEvent.NavigatePreview(index))
     }
 
@@ -175,6 +160,13 @@ class MainViewModel @Inject constructor(
             )
         }
     }
+
+    private fun updateSelectedIndex(index: Int){
+        _uiState.update {
+            it.copy(selectedIndex = index)
+        }
+    }
+
 
     fun onPreviewFragmentClosing() {
         _uiState.update {
@@ -190,4 +182,17 @@ class MainViewModel @Inject constructor(
             it.copy(isBottomSheetExpanded = isExpanded)
         }
     }
+
+    fun onMarkerClicked(tag: SnapPointTag) {
+        Log.d("TAG", "onMarkerClicked: $tag")
+        updateSelectedIndex(tag.postIndex)
+        updateFocusedIndex(tag.snapPointIndex)
+    }
+
+    private fun updateFocusedIndex(index: Int) {
+        _uiState.update {
+            it.copy(focusedIndex = index)
+        }
+    }
+
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
@@ -7,7 +7,6 @@ import com.boostcampwm2023.snappoint.presentation.model.PositionState
 import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
 import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
 import com.boostcampwm2023.snappoint.presentation.model.SnapPointTag
-import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.MarkerOptions
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.BufferOverflow
@@ -184,16 +183,14 @@ class MainViewModel @Inject constructor(
     }
 
     fun onMarkerClicked(tag: SnapPointTag) {
-        Log.d("TAG", "onMarkerClicked: $tag")
-        //updateSelectedIndex(tag.postIndex)
-        updateFocusedIndex(tag.postIndex, tag.snapPointIndex)
+        updateClickedSnapPoint(tag.postIndex, tag.snapPointIndex)
     }
 
-    private fun updateFocusedIndex(index1: Int, index2: Int) {
+    private fun updateClickedSnapPoint(postIndex: Int, snapPointIndex: Int) {
         _uiState.update {
             it.copy(
-                selectedIndex = index1,
-                focusedIndex = index2)
+                selectedIndex = postIndex,
+                focusedIndex = snapPointIndex)
         }
     }
 

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
@@ -185,13 +185,15 @@ class MainViewModel @Inject constructor(
 
     fun onMarkerClicked(tag: SnapPointTag) {
         Log.d("TAG", "onMarkerClicked: $tag")
-        updateSelectedIndex(tag.postIndex)
-        updateFocusedIndex(tag.snapPointIndex)
+        //updateSelectedIndex(tag.postIndex)
+        updateFocusedIndex(tag.postIndex, tag.snapPointIndex)
     }
 
-    private fun updateFocusedIndex(index: Int) {
+    private fun updateFocusedIndex(index1: Int, index2: Int) {
         _uiState.update {
-            it.copy(focusedIndex = index)
+            it.copy(
+                selectedIndex = index1,
+                focusedIndex = index2)
         }
     }
 

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/model/SnapPointTag.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/model/SnapPointTag.kt
@@ -1,0 +1,6 @@
+package com.boostcampwm2023.snappoint.presentation.model
+
+data class SnapPointTag(
+    val postIndex: Int,
+    val snapPointIndex: Int
+)

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/preview/PreviewFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/preview/PreviewFragment.kt
@@ -46,9 +46,7 @@ class PreviewFragment : BaseFragment<FragmentPreviewBinding>(R.layout.fragment_p
 
     override fun onDestroyView() {
         super.onDestroyView()
-        Log.d("LOG", "onDestroyView: asd")
         mainViewModel.onPreviewFragmentClosing()
-        Log.d("LOG", "onDestroyView: asdasd")
 
     }
 
@@ -63,7 +61,7 @@ class PreviewFragment : BaseFragment<FragmentPreviewBinding>(R.layout.fragment_p
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.RESUMED){
                 mainViewModel.uiState.collect{
-                    previewViewModel.updatePost(it.posts[0])
+                    previewViewModel.updatePost(it.posts[it.selectedIndex])
                 }
             }
         }
@@ -71,10 +69,6 @@ class PreviewFragment : BaseFragment<FragmentPreviewBinding>(R.layout.fragment_p
 
     private fun setScrollEvent() {
         binding.rcvPreview.setOnScrollChangeListener { _, _, _, _, _ ->
-            Log.d(
-                "LOG",
-                "IDX: ${layoutManager.getPosition(snapHelper.findSnapView(layoutManager)!!)}"
-            )
         }
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/util/SnapPointUtil.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/util/SnapPointUtil.kt
@@ -12,12 +12,19 @@ import coil.request.CachePolicy
 import coil.request.ImageRequest
 import coil.transform.CircleCropTransformation
 import com.boostcampwm2023.snappoint.R
+import com.boostcampwm2023.snappoint.presentation.model.SnapPointTag
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.android.gms.maps.model.MarkerOptions
 
 
-suspend fun GoogleMap.addImageMarker(context: Context, markerOptions: MarkerOptions, uri: String){
+suspend fun GoogleMap.addImageMarker(
+    context: Context,
+    markerOptions: MarkerOptions,
+    uri: String,
+    tag: SnapPointTag,
+    focused: Boolean,
+){
 
     val request = ImageRequest.Builder(context)
         .data(uri)
@@ -27,9 +34,20 @@ suspend fun GoogleMap.addImageMarker(context: Context, markerOptions: MarkerOpti
         .build()
     val result = ImageLoader(context).execute(request).drawable
 
-    val userImage = (result as BitmapDrawable).bitmap.scale(width = 69.px(), height = 69.px())
-    val container = BitmapFactory.decodeResource(context.resources, R.drawable.icon_snap_point_container).scale(width = 74.px(), height = 74.px())
-    val snapPointUnFocused = BitmapFactory.decodeResource(context.resources, R.drawable.icon_snap_point_unfocused).scale(width = 85.px(), height = 100.px())
+    val userImage = (result as BitmapDrawable).bitmap
+        .scale(width = 69.px(), height = 69.px())
+    val container = BitmapFactory.decodeResource(
+        context.resources,
+        R.drawable.icon_snap_point_container
+    ).scale(width = 74.px(), height = 74.px())
+    val snapPointUnFocused = BitmapFactory.decodeResource(
+        context.resources,
+        if(focused) {
+            R.drawable.icon_snap_point_focused
+        } else {
+            R.drawable.icon_snap_point_unfocused
+        }
+    ).scale(width = 85.px(), height = 100.px())
 
     val snapPoint = mergeToSnapPointBitmap(listOf(snapPointUnFocused, container, userImage))
 
@@ -37,7 +55,9 @@ suspend fun GoogleMap.addImageMarker(context: Context, markerOptions: MarkerOpti
         BitmapDescriptorFactory.fromBitmap(
             snapPoint
         )
-    ))
+    )).apply {
+        this?.tag = tag
+    }
 }
 
 fun mergeToSnapPointBitmap(bitmaps: List<Bitmap>): Bitmap {

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -11,4 +11,5 @@
     <color name="surfaceContainerHighest">#E3E3DB</color>
     <color name="surfaceContainerLow">#F5F4EC</color>
     <color name="errorContainer">#93000A</color>
+    <color name="error80">#FF5449</color>
 </resources>


### PR DESCRIPTION
## 작업 개요

- [x] SnapPoint 클릭 이벤트 연결 및 강조 표시
- [x] 강조된 SnapPoint의 경로 나타내기
- [x] PreviewFragment 게시물 연결

## 작업 사항

SnapPoint를 그릴 때, 하나의 함수를 호출해 경로까지 그릴 수 있도록 구현을 변경하였습니다.
ImageMarker에 Post의 Index값과 해당 SnapPoint의 Index값을 포함하는 SnapPointTag를 파라미터로 함께 전달하여 GoogleMap Marker의 Tag로 지정하고, ClickEvent가 발생했을 때 tag의 값을 ViewModel에 전달해 로직을 수행할 수 있도록 구현했습니다.

## 고민한 점들(필수 X)

MainUiState 내부에 Post들이 있습니다.
Post의 상태는 많이 변하지 않는 상태에서, 다른 값들이 변할 때 SnapPoint를 다시 그리게 됩니다.
해당 로직에서 불필요한 렌더링이 일어나게 되기 때문에, MainUiState와 SnapPoint를 나눌 것을 고려 중입니다.

## 스크린샷(필수 X)
[단일-핀-선택-및-강조.webm](https://github.com/boostcampwm2023/and01-SnapPoint/assets/41473557/184eb7a3-4508-4a2c-827a-075e7792e4b3)

