### PR TITLE
Refactor: 안드로이드 코드 리팩토링

### DIFF
--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundFragment.kt
@@ -1,7 +1,6 @@
 package com.boostcampwm2023.snappoint.presentation.around
 
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
@@ -53,5 +52,4 @@ class AroundFragment : BaseFragment<FragmentAroundBinding>(R.layout.fragment_aro
             vm = aroundViewModel
         }
     }
-
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundViewModel.kt
@@ -18,11 +18,10 @@ class AroundViewModel @Inject constructor(
 
 ) : ViewModel() {
 
-    private val _uiState: MutableStateFlow<AroundUiState> = MutableStateFlow(AroundUiState(
-        onPreviewButtonClicked = { index ->
-            previewButtonClicked(index)
-        }
-    ))
+    private val _uiState: MutableStateFlow<AroundUiState> = MutableStateFlow(
+        AroundUiState(
+            onPreviewButtonClicked = { index -> previewButtonClicked(index) })
+    )
     val uiState: StateFlow<AroundUiState> = _uiState.asStateFlow()
 
     private val _event: MutableSharedFlow<AroundEvent> = MutableSharedFlow(

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/BlockItemEventListener.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/BlockItemEventListener.kt
@@ -1,0 +1,11 @@
+package com.boostcampwm2023.snappoint.presentation.createpost
+
+interface BlockItemEventListener {
+    val onTextChange: (Int, String) -> Unit
+    val onDeleteButtonClick: (Int) -> Unit
+    val onEditButtonClick: (Int) -> Unit
+    val onCheckButtonClick: (Int) -> Unit
+    val onUpButtonClick: (Int) -> Unit
+    val onDownButtonClick: (Int) -> Unit
+    val onAddressIconClick: (Int) -> Unit
+}

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/BlockItemViewHolder.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/BlockItemViewHolder.kt
@@ -16,42 +16,39 @@ import com.google.android.material.card.MaterialCardView
 
 sealed class BlockItemViewHolder(
     binding: ViewDataBinding,
-    onContentChanged: (Int, String) -> Unit
+    blockItemEvent: BlockItemEventListener,
 ) : RecyclerView.ViewHolder(binding.root) {
 
-    val textWatcher = EditTextWatcher(onContentChanged)
+    val textWatcher = EditTextWatcher(blockItemEvent.onTextChange)
 
     abstract fun attachTextWatcherToEditText()
     abstract fun detachTextWatcherFromEditText()
 
     class TextBlockViewHolder(
         private val binding: ItemTextBlockBinding,
-        private val onContentChanged: (Int, String) -> Unit,
-        private val onEditButtonClicked: (Int) -> Unit,
-        private val onCheckButtonClicked: (Int) -> Unit,
-        private val onUpButtonClicked: (Int) -> Unit,
-        private val onDownButtonClicked: (Int) -> Unit,
-        private val onDeleteButtonClicked: (Int) -> Unit,
-    ) : BlockItemViewHolder(binding, onContentChanged) {
+        private val blockItemEvent: BlockItemEventListener,
+    ) : BlockItemViewHolder(binding, blockItemEvent) {
 
-        fun bind(block: PostBlockState.TEXT, position: Int) {
-            binding.tilText.editText?.setText(block.content)
-            binding.onDeleteButtonClick = { onDeleteButtonClicked(position) }
-            binding.btnEditBlock.setOnClickListener {
-                itemView.rootView.clearFocus()
-                onEditButtonClicked(position)
+        fun bind(block: PostBlockState.TEXT, index: Int) {
+            with(binding) {
+                tilText.editText?.setText(block.content)
+                btnDeleteBlock.setOnClickListener { blockItemEvent.onDeleteButtonClick(index) }
+                btnEditBlock.setOnClickListener {
+                    itemView.rootView.clearFocus()
+                    blockItemEvent.onEditButtonClick(index)
+                }
+                btnEditComplete.setOnClickListener { blockItemEvent.onCheckButtonClick(index) }
+                btnUp.setOnClickListener {
+                    itemView.rootView.clearFocus()
+                    blockItemEvent.onUpButtonClick(index)
+                }
+                btnDown.setOnClickListener {
+                    itemView.rootView.clearFocus()
+                    blockItemEvent.onDownButtonClick(index)
+                }
+                editMode = block.isEditMode
             }
-            binding.btnEditComplete.setOnClickListener { onCheckButtonClicked(position) }
-            binding.btnUp.setOnClickListener {
-                itemView.rootView.clearFocus()
-                onUpButtonClicked(position)
-            }
-            binding.btnDown.setOnClickListener {
-                itemView.rootView.clearFocus()
-                onDownButtonClicked(position)
-            }
-            binding.editMode = block.isEditMode
-            textWatcher.updatePosition(position)
+            textWatcher.updatePosition(index)
         }
 
         override fun attachTextWatcherToEditText() {
@@ -65,33 +62,27 @@ sealed class BlockItemViewHolder(
 
     class ImageBlockViewHolder(
         private val binding: ItemImageBlockBinding,
-        private val onContentChanged: (Int, String) -> Unit,
-        private val onAddressIconClicked: (Int) -> Unit,
-        private val onDeleteButtonClicked: (Int) -> Unit,
-        private val onEditButtonClicked: (Int) -> Unit,
-        private val onCheckButtonClicked: (Int) -> Unit,
-        private val onUpButtonClicked: (position: Int) -> Unit,
-        private val onDownButtonClicked: (position: Int) -> Unit,
-    ) : BlockItemViewHolder(binding, onContentChanged) {
+        private val blockItemEvent: BlockItemEventListener,
+    ) : BlockItemViewHolder(binding, blockItemEvent) {
 
         fun bind(block: PostBlockState.IMAGE, index: Int) {
-            with(binding){
+            with(binding) {
                 tilDescription.editText?.setText(block.content)
                 tilAddress.editText?.setText(block.address)
-                onDeleteButtonClick = { onDeleteButtonClicked(index) }
+                btnDeleteBlock.setOnClickListener { blockItemEvent.onDeleteButtonClick(index) }
                 btnEditBlock.setOnClickListener {
                     itemView.rootView.clearFocus()
-                    onEditButtonClicked(index)
+                    blockItemEvent.onEditButtonClick(index)
                 }
-                tilAddress.setEndIconOnClickListener { onAddressIconClicked.invoke(index) }
-                btnEditComplete.setOnClickListener { onCheckButtonClicked(index) }
+                tilAddress.setEndIconOnClickListener { blockItemEvent.onAddressIconClick(index) }
+                btnEditComplete.setOnClickListener { blockItemEvent.onCheckButtonClick(index) }
                 btnUp.setOnClickListener {
                     itemView.rootView.clearFocus()
-                    onUpButtonClicked(index)
+                    blockItemEvent.onUpButtonClick(index)
                 }
                 btnDown.setOnClickListener {
                     itemView.rootView.clearFocus()
-                    onDownButtonClicked(index)
+                    blockItemEvent.onDownButtonClick(index)
                 }
                 uri = block.uri
                 editMode = block.isEditMode
@@ -143,7 +134,7 @@ fun MaterialCardView.isEditMode(editMode: Boolean) {
     val value = TypedValue()
     if (editMode) {
         context.theme.resolveAttribute(com.google.android.material.R.attr.colorSecondary, value, true)
-        strokeWidth =4
+        strokeWidth = 4
     } else {
         context.theme.resolveAttribute(com.google.android.material.R.attr.colorOutline, value, true)
         strokeWidth = 1

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostActivity.kt
@@ -76,7 +76,7 @@ class CreatePostActivity : BaseActivity<ActivityCreatePostBinding>(R.layout.acti
         collectViewModelData()
     }
 
-    fun initBinding() {
+    private fun initBinding() {
         with(binding) {
             vm = viewModel
         }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostListAdapter.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostListAdapter.kt
@@ -9,13 +9,7 @@ import com.boostcampwm2023.snappoint.databinding.ItemTextBlockBinding
 import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
 
 class CreatePostListAdapter(
-    private val onAddressIconClicked: (Int) -> Unit,
-    private val onContentChanged: (Int, String) -> Unit,
-    private val onDeleteButtonClicked: (Int) -> Unit,
-    private val onEditButtonClicked: (Int) -> Unit,
-    private val onCheckButtonClicked: (Int) -> Unit,
-    private val onUpButtonClicked: (position: Int) -> Unit,
-    private val onDownButtonClicked: (position: Int) -> Unit,
+    private val blockItemEvent: BlockItemEventListener
 ) : RecyclerView.Adapter<BlockItemViewHolder>() {
 
     private var blocks: MutableList<PostBlockState> = mutableListOf()
@@ -58,29 +52,30 @@ class CreatePostListAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BlockItemViewHolder {
         val inflater = LayoutInflater.from(parent.context)
+        val itemEvent = object : BlockItemEventListener {
+            override val onTextChange: (Int, String) -> Unit = blockItemEvent.onTextChange
+            override val onDeleteButtonClick: (Int) -> Unit = { index ->
+                blockItemEvent.onDeleteButtonClick(index)
+                deleteBlocks(index)
+            }
+            override val onEditButtonClick: (Int) -> Unit = blockItemEvent.onEditButtonClick
+            override val onCheckButtonClick: (Int) -> Unit = blockItemEvent.onCheckButtonClick
+            override val onUpButtonClick: (Int) -> Unit = { index ->
+                blockItemEvent.onUpButtonClick(index)
+                moveUpBlock(index)
+            }
+            override val onDownButtonClick: (Int) -> Unit = { index ->
+                blockItemEvent.onDownButtonClick(index)
+                moveDownBlock(index)
+            }
+            override val onAddressIconClick: (Int) -> Unit = blockItemEvent.onAddressIconClick
+        }
 
         when (viewType) {
             ViewType.IMAGE.ordinal -> {
                 return BlockItemViewHolder.ImageBlockViewHolder(
                     binding = ItemImageBlockBinding.inflate(inflater, parent, false),
-                    onContentChanged = onContentChanged,
-                    onAddressIconClicked = { index ->
-                        onAddressIconClicked(index)
-                    },
-                    onDeleteButtonClicked = { index ->
-                        onDeleteButtonClicked(index)
-                        deleteBlocks(index)
-                    },
-                    onEditButtonClicked = onEditButtonClicked,
-                    onCheckButtonClicked = onCheckButtonClicked,
-                    onUpButtonClicked = { index ->
-                        onUpButtonClicked(index)
-                        moveUpBlock(index)
-                    },
-                    onDownButtonClicked = { index ->
-                        onDownButtonClicked(index)
-                        moveDownBlock(index)
-                    },
+                    blockItemEvent = itemEvent
                 )
             }
 
@@ -90,15 +85,7 @@ class CreatePostListAdapter(
         }
         return BlockItemViewHolder.TextBlockViewHolder(
             binding = ItemTextBlockBinding.inflate(inflater, parent, false),
-            onContentChanged = onContentChanged,
-            onDeleteButtonClicked = { index ->
-                onDeleteButtonClicked(index)
-                deleteBlocks(index)
-            },
-            onEditButtonClicked = onEditButtonClicked,
-            onCheckButtonClicked = onCheckButtonClicked,
-            onUpButtonClicked = onUpButtonClicked,
-            onDownButtonClicked = onDownButtonClicked,
+            blockItemEvent = itemEvent
         )
     }
 
@@ -132,35 +119,12 @@ class CreatePostListAdapter(
     }
 }
 
-@BindingAdapter(
-    "blocks",
-    "onContentChange",
-    "onDeleteButtonClick",
-    "onEditButtonClick",
-    "onCheckButtonClick",
-    "onUpButtonClick",
-    "onDownButtonClick",
-    "onAddressIconClick"
-)
+@BindingAdapter("blocks", "blockItemEvent")
 fun RecyclerView.bindRecyclerViewAdapter(
     blocks: List<PostBlockState>,
-    onContentChanged: (Int, String) -> Unit,
-    onDeleteButtonClicked: (Int) -> Unit,
-    onEditButtonClicked: (Int) -> Unit,
-    onCheckButtonClicked: (Int) -> Unit,
-    onUpButtonClicked: (Int) -> Unit,
-    onDownButtonClicked: (Int) -> Unit,
-    onAddressIconClicked: (Int) -> Unit
+    blockItemEvent: BlockItemEventListener
 ) {
-    if (adapter == null) adapter = CreatePostListAdapter(
-        onDeleteButtonClicked = onDeleteButtonClicked,
-        onContentChanged = onContentChanged,
-        onEditButtonClicked = onEditButtonClicked,
-        onCheckButtonClicked = onCheckButtonClicked,
-        onUpButtonClicked = onUpButtonClicked,
-        onDownButtonClicked = onDownButtonClicked,
-        onAddressIconClicked = onAddressIconClicked
-    )
+    if (adapter == null) adapter = CreatePostListAdapter(blockItemEvent)
 
     when {
         // 아이템 추가

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostUiState.kt
@@ -1,19 +1,12 @@
 package com.boostcampwm2023.snappoint.presentation.createpost
 
-import android.net.Uri
 import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
 
 data class CreatePostUiState(
     val title: String = "",
     val postBlocks: List<PostBlockState> = mutableListOf(),
-    val onTextChanged: (index: Int, content: String) -> Unit,
-    val onDeleteButtonClicked: (position: Int) -> Unit,
-    val onAddressIconClicked: (index: Int) -> Unit,
-    val onEditButtonClicked: (position: Int) -> Unit,
-    val onCheckButtonClicked: (position: Int) -> Unit,
-    val onUpButtonClicked: (position: Int) -> Unit,
-    val onDownButtonClicked: (position: Int) -> Unit,
     val isLoading: Boolean = false,
+    val blockItemEvent: BlockItemEventListener,
 )
 
 

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostViewModel.kt
@@ -30,27 +30,15 @@ class CreatePostViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<CreatePostUiState> = MutableStateFlow(CreatePostUiState(
-        onTextChanged = { index, content ->
-            updatePostBlocks(index, content)
+        blockItemEvent = object : BlockItemEventListener {
+            override val onTextChange: (Int, String) -> Unit = { index, content -> updatePostBlocks(index, content) }
+            override val onDeleteButtonClick: (Int) -> Unit = { index -> deletePostBlock(index) }
+            override val onEditButtonClick: (Int) -> Unit = { index -> changeToEditMode(index) }
+            override val onCheckButtonClick: (Int) -> Unit = { position -> clearEditMode(position) }
+            override val onUpButtonClick: (Int) -> Unit = { position -> moveUp(position) }
+            override val onDownButtonClick: (Int) -> Unit = { position -> moveDown(position) }
+            override val onAddressIconClick: (Int) -> Unit = { index -> findAddress(index) }
         },
-        onDeleteButtonClicked = { index ->
-            deletePostBlock(index)
-        },
-        onAddressIconClicked = { index ->
-            findAddress(index)
-        },
-        onEditButtonClicked = { position ->
-            changeToEditMode(position)
-        },
-        onCheckButtonClicked = { position ->
-            clearEditMode(position)
-        },
-        onUpButtonClicked = { position ->
-            moveUp(position)
-        },
-        onDownButtonClicked = { position ->
-            moveDown(position)
-        }
     ))
 
     val uiState: StateFlow<CreatePostUiState> = _uiState.asStateFlow()

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -194,6 +194,9 @@ class MainActivity :
         binding.bnv.setOnItemSelectedListener { menuItem ->
             navController.popBackStack()
             navController.navigate(menuItem.itemId)
+            if (bottomSheetBehavior.state == BottomSheetBehavior.STATE_COLLAPSED) {
+                bottomSheetBehavior.state = BottomSheetBehavior.STATE_HALF_EXPANDED
+            }
             true
         }
     }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -197,7 +197,7 @@ class MainActivity :
         binding.bnv.setOnItemSelectedListener { menuItem ->
             navController.popBackStack()
             navController.navigate(menuItem.itemId)
-            if (bottomSheetBehavior.state == BottomSheetBehavior.STATE_COLLAPSED) {
+            if(bottomSheetBehavior.state == BottomSheetBehavior.STATE_COLLAPSED) {
                 bottomSheetBehavior.state = BottomSheetBehavior.STATE_HALF_EXPANDED
             }
             true

--- a/android/app/src/main/res/layout/activity_create_post.xml
+++ b/android/app/src/main/res/layout/activity_create_post.xml
@@ -132,13 +132,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             android:padding="20dp"
             blocks="@{vm.uiState.postBlocks}"
-            onContentChange="@{vm.uiState.onTextChanged}"
-            onDeleteButtonClick="@{vm.uiState.onDeleteButtonClicked}"
-            onAddressIconClick = "@{vm.uiState.onAddressIconClicked}"
-            onEditButtonClick="@{vm.uiState.onEditButtonClicked}"
-            onCheckButtonClick="@{vm.uiState.onCheckButtonClicked}"
-            onUpButtonClick="@{vm.uiState.onUpButtonClicked}"
-            onDownButtonClick="@{vm.uiState.onDownButtonClicked}"
+            blockItemEvent="@{vm.uiState.blockItemEvent}"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             tools:listitem="@layout/item_text_block"/>
 

--- a/android/app/src/main/res/layout/item_image_block.xml
+++ b/android/app/src/main/res/layout/item_image_block.xml
@@ -5,11 +5,7 @@
     <data>
 
         <import type="android.view.View"/>
-        <import type="kotlin.jvm.functions.Function0"/>
         <import type="kotlin.Unit"/>
-        <variable
-            name="onDeleteButtonClick"
-            type="Function0&lt;Unit>" />
         <variable
             name="uri"
             type="android.net.Uri" />
@@ -47,7 +43,6 @@
             android:padding="16dp"
             android:layout_marginVertical="8dp"
             app:tint="@color/errorContainer"
-            android:onClick="@{() -> onDeleteButtonClick.invoke()}"
             android:visibility="@{editMode ? View.INVISIBLE : View.VISIBLE}"/>
 
         <ImageButton


### PR DESCRIPTION
## 작업 개요
- Bottom Sheet가 접힌 상태에서 Bottom Navigation View의 아이템 클릭 시 Bottom Sheet가 바로 나오도록 구현하였습니다.
- 주변 게시글 화면과 게시글 작성 화면과 관련된 코드의 리팩토링을 진행하였습니다.

## 작업 사항
- Bottom Navigation View의 아이템을 클릭할 때 Bottom Sheet의 state가 `STATE_COLLAPSED`라면 `STATE_HALF_EXPANDED`로 설정하도록 구현하였습니다.
- 주변 게시글 화면과 게시글 작성 화면에 관련된 코드들의 리팩토링을 1차적으로 진행하였습니다. 그 중 RecyclerView의 아이템에 클릭 리스너를 전달할 때 `Adapter`와 `ViewHolder`에 파라미터가 너무 많아지는 문제를 `interface`를 통해 전달하도록 수정하여 해결하였습니다.