### PR TITLE
Feature(#32): 스냅포인트 클릭 시 미리보기 및 게시글 목록 수정

### DIFF
--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/PostItemViewHolder.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/PostItemViewHolder.kt
@@ -1,8 +1,13 @@
 package com.boostcampwm2023.snappoint.presentation.around
 
 import android.view.View
+import android.widget.ImageView
 import android.widget.LinearLayout
+import androidx.databinding.BindingAdapter
 import androidx.recyclerview.widget.RecyclerView
+import coil.load
+import coil.request.CachePolicy
+import coil.transform.CircleCropTransformation
 import com.boostcampwm2023.snappoint.databinding.ItemAroundPostBinding
 import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
 import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
@@ -23,6 +28,11 @@ class PostItemViewHolder(
             postItem = item
             isExpand = expandState
 
+            root.setOnClickListener {
+                expandState = expandState.not()
+                toggleLayout(expandState, btnExpand, layoutExpanded)
+                onExpandButtonClicked(index)
+            }
             btnExpand.setOnClickListener {
                 expandState = expandState.not()
                 toggleLayout(expandState, it, layoutExpanded)
@@ -41,6 +51,23 @@ class PostItemViewHolder(
             ExpandButtonToggleAnimation.expand(expandedLayout)
         } else {
             ExpandButtonToggleAnimation.collapse(expandedLayout)
+        }
+    }
+}
+
+@BindingAdapter("profileImage")
+fun ImageView.bindProfileImage(postBlocks: List<PostBlockState>) {
+    postBlocks.forEach { block ->
+        when (block) {
+            is PostBlockState.IMAGE -> {
+                load(block.content) {
+                    memoryCachePolicy(CachePolicy.ENABLED)
+                    transformations(CircleCropTransformation())
+                }
+                return
+            }
+
+            else -> {}
         }
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -102,7 +102,8 @@ class MainActivity :
                             }
 
                             is MainActivityEvent.NavigatePreview -> {
-                                openPreviewFragment()
+                                if (navController.currentDestination?.id != R.id.previewFragment)
+                                    openPreviewFragment()
                             }
                         }
                     }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
@@ -183,6 +183,7 @@ class MainViewModel @Inject constructor(
 
     fun onMarkerClicked(tag: SnapPointTag) {
         updateClickedSnapPoint(tag.postIndex, tag.snapPointIndex)
+        _event.tryEmit(MainActivityEvent.NavigatePreview(tag.postIndex))
     }
 
     fun focusOfImageMoved(imageIndex: Int) {

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/preview/PreviewFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/preview/PreviewFragment.kt
@@ -1,7 +1,6 @@
 package com.boostcampwm2023.snappoint.presentation.preview
 
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
@@ -62,7 +61,9 @@ class PreviewFragment : BaseFragment<FragmentPreviewBinding>(R.layout.fragment_p
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.RESUMED){
                 mainViewModel.uiState.collect{
-                    previewViewModel.updatePost(it.posts[it.selectedIndex])
+                    if (it.selectedIndex > -1) {
+                        previewViewModel.updatePost(it.posts[it.selectedIndex])
+                    }
                     moveScroll(it.focusedIndex)
                 }
             }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/preview/PreviewFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/preview/PreviewFragment.kt
@@ -76,7 +76,11 @@ class PreviewFragment : BaseFragment<FragmentPreviewBinding>(R.layout.fragment_p
     }
 
     private fun setScrollEvent() {
-        binding.rcvPreview.setOnScrollChangeListener { _, _, _, _, _ ->
+        binding.rcvPreview.setOnScrollChangeListener { _, _, _, scrollX, _ ->
+            if (scrollX == 0) {
+                layoutManager.scrollToPosition(mainViewModel.uiState.value.focusedIndex)
+                return@setOnScrollChangeListener
+            }
             val currentFocusImageIndex =
                 layoutManager.getPosition(
                     snapHelper.findSnapView(layoutManager) ?: return@setOnScrollChangeListener

--- a/android/app/src/main/res/layout/item_around_post.xml
+++ b/android/app/src/main/res/layout/item_around_post.xml
@@ -38,7 +38,8 @@
             android:layout_marginStart="16dp"
             app:layout_constraintBottom_toBottomOf="@id/btn_expand"
             app:layout_constraintStart_toStartOf="@id/cv_around_post"
-            app:layout_constraintTop_toTopOf="@id/btn_expand" />
+            app:layout_constraintTop_toTopOf="@id/btn_expand"
+            profileImage="@{postItem.postBlocks}"/>
 
         <TextView
             android:id="@+id/tv_post_title"


### PR DESCRIPTION
## 작업 개요
- 지도상의 스냅포인트를 클릭 시 바텀 시트에 미리보기 화면이 표시
- 클릭한 스냅포인트의 사진을 보여주도록 구현
- 게시글 목록에서 제목 앞에 사진 추가
- 게시글 목록의 아이템 클릭 시 확장 버튼과 동일한 동작 수행

## 작업 사항
- 스냅포인트 터치 시 미리보기 화면을 띄워주도록 구현하였습니다.
- 미리보기 화면에서는 터치한 스냅포인트에 해당하는 사진을 보여주도록 구현하였습니다.
- 게시글 목록 화면의 아이템에 사진을 추가하였습니다.
- 게시글 목록의 각 아이템의 root view에 확장 버튼과 같은 동작을 수행하도록 `setOnClickListener`를 지정하였습니다.

## 스크린샷(필수 X)
[Screen_recording_20231123_221559.webm](https://github.com/boostcampwm2023/and01-SnapPoint/assets/85796984/625db3a0-06d4-4b1d-a7b4-87ba1ee91cf5)

[Screen_recording_20231123_225414.webm](https://github.com/boostcampwm2023/and01-SnapPoint/assets/85796984/a42b09a9-2da0-47d7-8e9c-c8dce85c3f7a)

