### PR TITLE
Feature(#7): 스냅 포인트 이미지 설정

### DIFF
--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -175,13 +175,15 @@ class MainActivity :
                     if(postIndex == selectedIndex){
                         drawRoutes(selectedIndex)
                     }
+                    val mediaBlock = viewModel.uiState.value.posts[postIndex].postBlocks
+                        .filterIsInstance<PostBlockState.IMAGE>()
                     snapPointState.markerOptions.forEachIndexed { snapPointIndex, markerOptions ->
                         val focused =
                             (postIndex == viewModel.uiState.value.selectedIndex) && (snapPointIndex == viewModel.uiState.value.focusedIndex)
                         map.addImageMarker(
                             context = this@MainActivity,
                             markerOptions = markerOptions,
-                            uri = "https://t3.gstatic.com/licensed-image?q=tbn:ANd9GcRoT6NNDUONDQmlthWrqIi_frTjsjQT4UZtsJsuxqxLiaFGNl5s3_pBIVxS6-VsFUP_",
+                            uri = mediaBlock[snapPointIndex].content,
                             tag = SnapPointTag(postIndex = postIndex, snapPointIndex = snapPointIndex),
                             focused = focused
                         )

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
@@ -69,7 +69,7 @@ class MainViewModel @Inject constructor(
                             ),
                             PostBlockState.IMAGE(
                                 content = "https://i.namu.wiki/i/Nvsy3_i1lyInOB79UBbcDeR6MocJ4C8TBN8NjepPwqTnojCbb3Xwge9gQXfAGgW74ZA3c3i16odhBLE0bSwgFA.webp",
-                                position = PositionState(10.004, 10.003),
+                                position = PositionState(10.004, 10.004),
                                 description = "이것은 악어~",
                                 address = "null"
                             ),

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
@@ -46,7 +46,7 @@ class MainViewModel @Inject constructor(
                     PostSummaryState(
                         title = "하이",
                         author = "원승빈",
-                        timeStamp = "123",
+                        timeStamp = "2 Days Ago",
                         postBlocks = listOf(
                             PostBlockState.TEXT(
                                 content = "안녕하세요, 하하"
@@ -55,12 +55,12 @@ class MainViewModel @Inject constructor(
                                 content = "https://health.chosun.com/site/data/img_dir/2023/07/17/2023071701753_0.jpg",
                                 position = PositionState(10.001, 10.002),
                                 description = "고양이입니다.",
-                                address = "고양이를 발견한 동네"
+                                address = "null"
                             ),PostBlockState.IMAGE(
                                 content = "https://pds.joongang.co.kr/news/component/htmlphoto_mmdata/201901/20/28017477-0365-4a43-b546-008b603da621.jpg",
                                 position = PositionState(10.005, 10.006),
                                 description = "강아징입니다.",
-                                address = "내가 키우는 강아지"
+                                address = "null"
                             ),
                             PostBlockState.TEXT(
                                 content = "ㅎㅇ염"
@@ -71,40 +71,40 @@ class MainViewModel @Inject constructor(
                                 content = "https://i.namu.wiki/i/Nvsy3_i1lyInOB79UBbcDeR6MocJ4C8TBN8NjepPwqTnojCbb3Xwge9gQXfAGgW74ZA3c3i16odhBLE0bSwgFA.webp",
                                 position = PositionState(10.004, 10.003),
                                 description = "이것은 악어~",
-                                address = "제일 좋아하는 동물이에용"
+                                address = "null"
                             ),
                             PostBlockState.IMAGE(
-                                content = "https://i.namu.wiki/i/Nvsy3_i1lyInOB79UBbcDeR6MocJ4C8TBN8NjepPwqTnojCbb3Xwge9gQXfAGgW74ZA3c3i16odhBLE0bSwgFA.webp",
+                                content = "https://upload.wikimedia.org/wikipedia/commons/4/41/Siberischer_tiger_de_edit02.jpg",
                                 position = PositionState(10.008, 9.998),
-                                description = "이것은 악어~",
-                                address = "제일 좋아하는 동물이에용"
+                                description = "어흥",
+                                address = "null"
                             ),
                         )
                     ),
                     PostSummaryState(
-                        title = "마커 테스트",
-                        author = "TEST",
-                        timeStamp = "1",
+                        title = "여름 철새 구경",
+                        author = "익명",
+                        timeStamp = "3 Weeks Ago",
                         postBlocks = listOf(
                             PostBlockState.TEXT(
                                 content = "123"
                             ),
                             PostBlockState.IMAGE(
-                                content = "https://i.namu.wiki/i/Nvsy3_i1lyInOB79UBbcDeR6MocJ4C8TBN8NjepPwqTnojCbb3Xwge9gQXfAGgW74ZA3c3i16odhBLE0bSwgFA.webp",
+                                content = "https://upload.wikimedia.org/wikipedia/commons/8/85/Columbina_passerina.jpg",
                                 position = PositionState(10.0, 9.7),
-                                description = "test",
+                                description = "비둘기야 먹자 구구구구",
                                 address = "address"
                             ),
                             PostBlockState.IMAGE(
-                                content = "https://i.namu.wiki/i/Nvsy3_i1lyInOB79UBbcDeR6MocJ4C8TBN8NjepPwqTnojCbb3Xwge9gQXfAGgW74ZA3c3i16odhBLE0bSwgFA.webp",
+                                content = "https://upload.wikimedia.org/wikipedia/commons/f/f0/Nipponia_nippon_20091230131054.png",
                                 position = PositionState(9.9, 10.1),
-                                description = "test",
+                                description = "떴따 오기",
                                 address = "address"
                             ),
                             PostBlockState.IMAGE(
-                                content = "https://i.namu.wiki/i/Nvsy3_i1lyInOB79UBbcDeR6MocJ4C8TBN8NjepPwqTnojCbb3Xwge9gQXfAGgW74ZA3c3i16odhBLE0bSwgFA.webp",
+                                content = "https://upload.wikimedia.org/wikipedia/commons/8/82/Watercock_%28Gallicrex_cinerea%29.jpg",
                                 position = PositionState(10.3, 10.5),
-                                description = "test",
+                                description = "뜸 부기",
                                 address = "address"
                             ),
                         )

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
@@ -53,12 +53,12 @@ class MainViewModel @Inject constructor(
                             ),
                             PostBlockState.IMAGE(
                                 content = "https://health.chosun.com/site/data/img_dir/2023/07/17/2023071701753_0.jpg",
-                                position = PositionState(10.001, 10.002),
+                                position = PositionState(37.421793077676774, -122.09180117366115),
                                 description = "고양이입니다.",
                                 address = "null"
                             ),PostBlockState.IMAGE(
                                 content = "https://pds.joongang.co.kr/news/component/htmlphoto_mmdata/201901/20/28017477-0365-4a43-b546-008b603da621.jpg",
-                                position = PositionState(10.005, 10.006),
+                                position = PositionState(37.41887606344049, -122.0879954078449),
                                 description = "강아징입니다.",
                                 address = "null"
                             ),
@@ -69,13 +69,13 @@ class MainViewModel @Inject constructor(
                             ),
                             PostBlockState.IMAGE(
                                 content = "https://i.namu.wiki/i/Nvsy3_i1lyInOB79UBbcDeR6MocJ4C8TBN8NjepPwqTnojCbb3Xwge9gQXfAGgW74ZA3c3i16odhBLE0bSwgFA.webp",
-                                position = PositionState(10.004, 10.004),
+                                position = PositionState(37.42155682099068, -122.08342886715077),
                                 description = "이것은 악어~",
                                 address = "null"
                             ),
                             PostBlockState.IMAGE(
                                 content = "https://upload.wikimedia.org/wikipedia/commons/4/41/Siberischer_tiger_de_edit02.jpg",
-                                position = PositionState(10.008, 9.998),
+                                position = PositionState(37.4227919844394, -122.08028507548029),
                                 description = "어흥",
                                 address = "null"
                             ),
@@ -91,19 +91,19 @@ class MainViewModel @Inject constructor(
                             ),
                             PostBlockState.IMAGE(
                                 content = "https://upload.wikimedia.org/wikipedia/commons/8/85/Columbina_passerina.jpg",
-                                position = PositionState(10.0, 9.7),
+                                position = PositionState(37.40837052881207, -122.10293026989889),
                                 description = "비둘기야 먹자 구구구구",
                                 address = "address"
                             ),
                             PostBlockState.IMAGE(
                                 content = "https://upload.wikimedia.org/wikipedia/commons/f/f0/Nipponia_nippon_20091230131054.png",
-                                position = PositionState(9.9, 10.1),
+                                position = PositionState(37.40272239693208, -122.06577824456974),
                                 description = "떴따 오기",
                                 address = "address"
                             ),
                             PostBlockState.IMAGE(
                                 content = "https://upload.wikimedia.org/wikipedia/commons/8/82/Watercock_%28Gallicrex_cinerea%29.jpg",
-                                position = PositionState(10.3, 10.5),
+                                position = PositionState(37.414911773823924, -122.0536102126485),
                                 description = "뜸 부기",
                                 address = "address"
                             ),


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#7): 스냅 포인트 대표 이미지 설정 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
- [x] 스냅 포인트에 해당 위치의 이미지 표시
- [x] 데이터 좌표 변경

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- 각 스냅포인트에 해당 위치의 이미지를 표시합니다.
- 데이터를 구글본사 주변으로 이동했습니다 (가상기기 위치)

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->
- 현재 위치 찾아가기 + 축소
![GIFS2](https://github.com/boostcampwm2023/and01-SnapPoint/assets/76683420/20cf71be-6930-475b-aecc-992d629c5930)

경로가 보이는 건 아직 정건님 브랜치와 머지가 안 돼서 생긴 버그입니다.