### PR TITLE
Refactor: cd actions job 나누기

### DIFF
--- a/.github/workflows/android-firebase-app-distribution.yml
+++ b/.github/workflows/android-firebase-app-distribution.yml
@@ -26,12 +26,17 @@ jobs:
       env:
         LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
         GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
-        APP_KEYSTORE: ${{ secrets.APP_KEYSTORE }}
       run: |
         echo "$LOCAL_PROPERTIES" > local.properties
         echo "$GOOGLE_SERVICES_JSON" > app/google-services.json
+
+    - name: Generate Keystore
+      env:
+        APP_KEYSTORE: ${{ secrets.APP_KEYSTORE }}
+      run: |
         echo "$APP_KEYSTORE" > keystore_b64.txt
-        base64 --decode --ignore-garbage keystore_b64.txt > app/keystore.jks
+        base64 --decode --ignore-garbage keystore_b64.txt > keystore.jks
+      working-directory: ./android/app
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew


### PR DESCRIPTION
keystorepassord를 찾을 수 없는 오류 - working directory가 달라 발생한 오류로 예상. 수정