### PR TITLE
Feature(#34): 주소 검색 및 카메라 이동

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
+
 @Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     alias(libs.plugins.androidApplication)
@@ -25,6 +27,7 @@ android {
         versionName = "0.1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField("String", "apiKey", getApiKey("MAPS_API_KEY"))
     }
 
     buildTypes {
@@ -43,11 +46,16 @@ android {
 
     buildFeatures{
         dataBinding = true
+        buildConfig = true
     }
 
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_17.majorVersion
     }
+}
+
+fun getApiKey(propertyKey: String) : String {
+    return gradleLocalProperties(rootDir, providers).getProperty(propertyKey)
 }
 
 dependencies {
@@ -97,6 +105,8 @@ dependencies {
     implementation (libs.play.services.maps)
     //location
     implementation (libs.play.services.location)
+    //places
+    implementation (libs.places)
 
     //mockwebserver
     testImplementation(libs.mockwebserver)

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -2,6 +2,7 @@ package com.boostcampwm2023.snappoint.presentation.main
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.location.Geocoder
 import android.os.Bundle
 import android.os.Looper
 import android.util.Log
@@ -337,6 +338,29 @@ class MainActivity :
                 .onEach { query -> getAddressAutoCompletion(query) }
                 .launchIn(lifecycleScope)
         }
+
+        onSearchButtonClickedInSearchView()
+    }
+
+    private fun onSearchButtonClickedInSearchView() {
+        val geocoder = Geocoder(applicationContext)
+
+        with(binding) {
+            sv.editText.setOnEditorActionListener { v, _, _ ->
+                val address = v.text.toString()
+                val results = geocoder.getFromLocationName(address, 1)
+
+                if (results == null || results.size == 0) {
+                    showToastMessage(R.string.search_location_fail)
+                } else {
+                    val latLng = LatLng(results[0].latitude, results[0].longitude)
+                    googleMap?.moveCamera(CameraUpdateFactory.newLatLng(latLng))
+                    bottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
+                    sv.hide()
+                }
+                true
+            }
+        }
     }
 
     private fun getAddressAutoCompletion(query: String) {
@@ -347,9 +371,6 @@ class MainActivity :
 
         placesClient.findAutocompletePredictions(request)
             .addOnSuccessListener { response ->
-//                for (prediction in response.autocompletePredictions) {
-//                    println(prediction.getFullText(null).toString())
-//                }
                 viewModel.updateAutoCompleteTexts(response.autocompletePredictions.map {
                     it.getFullText(null).toString()
                 })

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -56,6 +56,7 @@ import com.google.android.libraries.places.api.net.FindAutocompletePredictionsRe
 import com.google.android.libraries.places.api.net.PlacesClient
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCallback
+import com.google.android.material.search.SearchView
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.awaitClose
@@ -342,12 +343,18 @@ class MainActivity :
                 .debounce(500)
                 .onEach { query -> getAddressAutoCompletion(query) }
                 .launchIn(lifecycleScope)
-        }
 
-        binding.sv.editText.setOnEditorActionListener { v, _, _ ->
-            val address = v.text.toString()
-            moveCameraToAddress(address)
-            true
+            sv.editText.setOnEditorActionListener { v, _, _ ->
+                val address = v.text.toString()
+                moveCameraToAddress(address)
+                true
+            }
+
+            sv.addTransitionListener { _, _, afterState ->
+                if (afterState == SearchView.TransitionState.HIDDEN) {
+                    viewModel.updateAutoCompleteTexts(emptyList())
+                }
+            }
         }
     }
 

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -347,9 +347,12 @@ class MainActivity :
 
         placesClient.findAutocompletePredictions(request)
             .addOnSuccessListener { response ->
-                for (prediction in response.autocompletePredictions) {
-                    println(prediction.getFullText(null).toString())
-                }
+//                for (prediction in response.autocompletePredictions) {
+//                    println(prediction.getFullText(null).toString())
+//                }
+                viewModel.updateAutoCompleteTexts(response.autocompletePredictions.map {
+                    it.getFullText(null).toString()
+                })
             }.addOnFailureListener { exception ->
                 if (exception is ApiException) {
                     Log.e("TAG", "Place not found: ${exception.statusCode}")

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivityEvent.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivityEvent.kt
@@ -5,4 +5,5 @@ sealed class MainActivityEvent {
     data object NavigatePrev: MainActivityEvent()
     data object NavigateClose: MainActivityEvent()
     data class NavigatePreview(val index: Int): MainActivityEvent()
+    data class MoveCameraToAddress(val index: Int): MainActivityEvent()
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
@@ -2,6 +2,7 @@ package com.boostcampwm2023.snappoint.presentation.main
 
 import androidx.lifecycle.ViewModel
 import com.boostcampwm2023.snappoint.data.repository.PostRepository
+import com.boostcampwm2023.snappoint.presentation.main.search.SearchViewUiState
 import com.boostcampwm2023.snappoint.presentation.model.PositionState
 import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
 import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
@@ -26,6 +27,11 @@ class MainViewModel @Inject constructor(
 
     private val _uiState: MutableStateFlow<MainUiState> = MutableStateFlow(MainUiState())
     val uiState: StateFlow<MainUiState> = _uiState.asStateFlow()
+
+    private val _searchViewUiState: MutableStateFlow<SearchViewUiState> = MutableStateFlow(
+        SearchViewUiState()
+    )
+    val searchViewUiState: StateFlow<SearchViewUiState> = _searchViewUiState.asStateFlow()
 
     private val _event: MutableSharedFlow<MainActivityEvent> = MutableSharedFlow(
         extraBufferCapacity = 1,
@@ -197,6 +203,12 @@ class MainViewModel @Inject constructor(
             it.copy(
                 selectedIndex = postIndex,
                 focusedIndex = snapPointIndex)
+        }
+    }
+
+    fun updateAutoCompleteTexts(texts: List<String>) {
+        _searchViewUiState.update {
+            it.copy(texts = texts)
         }
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
@@ -29,7 +29,9 @@ class MainViewModel @Inject constructor(
     val uiState: StateFlow<MainUiState> = _uiState.asStateFlow()
 
     private val _searchViewUiState: MutableStateFlow<SearchViewUiState> = MutableStateFlow(
-        SearchViewUiState()
+        SearchViewUiState(onAutoCompleteItemClicked = { index ->
+            moveCameraToAddress(index)
+        })
     )
     val searchViewUiState: StateFlow<SearchViewUiState> = _searchViewUiState.asStateFlow()
 
@@ -210,5 +212,9 @@ class MainViewModel @Inject constructor(
         _searchViewUiState.update {
             it.copy(texts = texts)
         }
+    }
+
+    private fun moveCameraToAddress(index: Int) {
+        _event.tryEmit(MainActivityEvent.MoveCameraToAddress(index))
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/search/AutoCompletionViewHolder.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/search/AutoCompletionViewHolder.kt
@@ -1,0 +1,16 @@
+package com.boostcampwm2023.snappoint.presentation.main.search
+
+import androidx.recyclerview.widget.RecyclerView
+import com.boostcampwm2023.snappoint.databinding.ItemSearchAutoCompleteBinding
+
+class AutoCompletionViewHolder(
+    private val binding: ItemSearchAutoCompleteBinding
+) : RecyclerView.ViewHolder(binding.root) {
+
+    fun bind(string: String) {
+
+        with(binding) {
+            item = string
+        }
+    }
+}

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/search/AutoCompletionViewHolder.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/search/AutoCompletionViewHolder.kt
@@ -4,13 +4,15 @@ import androidx.recyclerview.widget.RecyclerView
 import com.boostcampwm2023.snappoint.databinding.ItemSearchAutoCompleteBinding
 
 class AutoCompletionViewHolder(
-    private val binding: ItemSearchAutoCompleteBinding
+    private val binding: ItemSearchAutoCompleteBinding,
+    private val onAutoCompleteItemClicked: (Int) -> Unit,
 ) : RecyclerView.ViewHolder(binding.root) {
 
-    fun bind(string: String) {
+    fun bind(string: String, index: Int) {
 
         with(binding) {
             item = string
+            root.setOnClickListener { onAutoCompleteItemClicked(index) }
         }
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/search/SearchViewListAdapter.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/search/SearchViewListAdapter.kt
@@ -1,0 +1,45 @@
+package com.boostcampwm2023.snappoint.presentation.main.search
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.databinding.BindingAdapter
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.boostcampwm2023.snappoint.databinding.ItemSearchAutoCompleteBinding
+
+class AutoCompletionListAdapter() : ListAdapter<String, AutoCompletionViewHolder>(diffUtil) {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AutoCompletionViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        return AutoCompletionViewHolder(
+            ItemSearchAutoCompleteBinding.inflate(
+                inflater,
+                parent,
+                false
+            )
+        )
+    }
+
+    override fun onBindViewHolder(holder: AutoCompletionViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    companion object {
+        val diffUtil = object : DiffUtil.ItemCallback<String>() {
+            override fun areItemsTheSame(oldItem: String, newItem: String): Boolean {
+                return oldItem == newItem
+            }
+
+            override fun areContentsTheSame(oldItem: String, newItem: String): Boolean {
+                return oldItem == newItem
+            }
+
+        }
+    }
+}
+
+@BindingAdapter("autoCompleteTexts")
+fun RecyclerView.bindRecyclerViewAdapter(texts: List<String>) {
+    if (adapter == null) adapter = AutoCompletionListAdapter()
+    (adapter as AutoCompletionListAdapter).submitList(texts)
+}

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/search/SearchViewListAdapter.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/search/SearchViewListAdapter.kt
@@ -8,20 +8,19 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.boostcampwm2023.snappoint.databinding.ItemSearchAutoCompleteBinding
 
-class AutoCompletionListAdapter() : ListAdapter<String, AutoCompletionViewHolder>(diffUtil) {
+class AutoCompletionListAdapter(
+    private val onAutoCompleteItemClicked: (Int) -> Unit
+) : ListAdapter<String, AutoCompletionViewHolder>(diffUtil) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AutoCompletionViewHolder {
         val inflater = LayoutInflater.from(parent.context)
         return AutoCompletionViewHolder(
-            ItemSearchAutoCompleteBinding.inflate(
-                inflater,
-                parent,
-                false
-            )
+            binding = ItemSearchAutoCompleteBinding.inflate(inflater, parent, false),
+            onAutoCompleteItemClicked = onAutoCompleteItemClicked
         )
     }
 
     override fun onBindViewHolder(holder: AutoCompletionViewHolder, position: Int) {
-        holder.bind(getItem(position))
+        holder.bind(getItem(position), position)
     }
 
     companion object {
@@ -38,8 +37,8 @@ class AutoCompletionListAdapter() : ListAdapter<String, AutoCompletionViewHolder
     }
 }
 
-@BindingAdapter("autoCompleteTexts")
-fun RecyclerView.bindRecyclerViewAdapter(texts: List<String>) {
-    if (adapter == null) adapter = AutoCompletionListAdapter()
+@BindingAdapter("autoCompleteTexts", "onAutoCompleteItemClick")
+fun RecyclerView.bindRecyclerViewAdapter(texts: List<String>, onAutoCompleteItemClicked:(Int) -> Unit) {
+    if (adapter == null) adapter = AutoCompletionListAdapter(onAutoCompleteItemClicked)
     (adapter as AutoCompletionListAdapter).submitList(texts)
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/search/SearchViewUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/search/SearchViewUiState.kt
@@ -1,5 +1,6 @@
 package com.boostcampwm2023.snappoint.presentation.main.search
 
 data class SearchViewUiState(
-    val texts: List<String> = emptyList()
+    val texts: List<String> = emptyList(),
+    val onAutoCompleteItemClicked: (Int) -> Unit = {},
 )

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/search/SearchViewUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/search/SearchViewUiState.kt
@@ -1,0 +1,5 @@
+package com.boostcampwm2023.snappoint.presentation.main.search
+
+data class SearchViewUiState(
+    val texts: List<String> = emptyList()
+)

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/util/Constants.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/util/Constants.kt
@@ -1,5 +1,8 @@
 package com.boostcampwm2023.snappoint.presentation.util
 
+import com.boostcampwm2023.snappoint.BuildConfig
+
 object Constants {
     const val BOTTOM_SHEET_HALF_EXPANDED_RATIO: Float = 0.45f
+    const val API_KEY = BuildConfig.MAPS_API_KEY
 }

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -74,7 +74,16 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     app:layout_anchor="@id/sb"
-                    android:id="@+id/sv"/>
+                    android:id="@+id/sv">
+
+                    <androidx.recyclerview.widget.RecyclerView
+                        android:id="@+id/rcv_search_auto_complete"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                        autoCompleteTexts="@{vm.searchViewUiState.texts}"/>
+
+                </com.google.android.material.search.SearchView>
 
                 <LinearLayout
                     android:id="@+id/bs"

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -81,7 +81,8 @@
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                        autoCompleteTexts="@{vm.searchViewUiState.texts}"/>
+                        autoCompleteTexts="@{vm.searchViewUiState.texts}"
+                        onAutoCompleteItemClick="@{vm.searchViewUiState.onAutoCompleteItemClicked}"/>
 
                 </com.google.android.material.search.SearchView>
 

--- a/android/app/src/main/res/layout/item_search_auto_complete.xml
+++ b/android/app/src/main/res/layout/item_search_auto_complete.xml
@@ -36,8 +36,7 @@
             app:layout_constraintStart_toEndOf="@id/iv_marker"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@id/iv_marker"
-            app:layout_constraintBottom_toBottomOf="@id/iv_marker"
-            tools:text="울산광역시 중구 신기11길 10-10"/>
+            app:layout_constraintBottom_toBottomOf="@id/iv_marker"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/app/src/main/res/layout/item_search_auto_complete.xml
+++ b/android/app/src/main/res/layout/item_search_auto_complete.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="item"
+            type="String" />
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp">
+
+        <ImageView
+            android:id="@+id/iv_marker"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/icon_location_pin"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"/>
+
+        <TextView
+            android:id="@+id/tv_auto_complete"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@{item}"
+            android:textSize="16sp"
+            android:ellipsize="marquee"
+            android:maxLines="1"
+            android:layout_marginStart="16dp"
+            app:layout_constraintStart_toEndOf="@id/iv_marker"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/iv_marker"
+            app:layout_constraintBottom_toBottomOf="@id/iv_marker"
+            tools:text="울산광역시 중구 신기11길 10-10"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/layout/item_search_auto_complete.xml
+++ b/android/app/src/main/res/layout/item_search_auto_complete.xml
@@ -14,6 +14,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:foreground="?attr/selectableItemBackground"
         android:padding="16dp">
 
         <ImageView

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -30,4 +30,5 @@
     <string name="login_activity_password">PASSWORD</string>
     <string name="login_activity_sign_in">SIGN IN</string>
     <string name="login_activity_fail">이메일 또는 비밀번호를 잘못 입력했습니다. 입력하신 내용을 다시 확인해주세요.</string>
+    <string name="search_location_fail">입력한 주소를 찾을 수 없습니다.\n다시 한번 확인해 주세요</string>
 </resources>

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ appcompat = "1.6.1"
 material = "1.10.0"
 constraintlayout = "2.1.4"
 hilt = "2.48"
+places = "3.3.0"
 retrofit = "2.9.0"
 retrofit2-kotlinx-serialization-converter = "1.0.0"
 nav-version = "2.7.5"
@@ -40,6 +41,7 @@ constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayo
 hilt-android = {group = "com.google.dagger", name = "hilt-android", version.ref = "hilt"}
 hilt-android-compiler = {group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt"}
 
+places = { module = "com.google.android.libraries.places:places", version.ref = "places" }
 retrofit = {group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit"}
 retrofit2-kotlinx-serialization-converter = {group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version.ref = "retrofit2-kotlinx-serialization-converter"}
 


### PR DESCRIPTION
## 작업 개요
- [x] SearchView에서 키워드 입력하고 키보드의 검색 버튼 클릭 시 검색 결과 표시
- [x] 검색 결과 클릭 시 해당 위치로 이동

## 작업 사항
- ~SearchView에서 키워드 입력 시, 0.5초간 기다렸다가 더 이상 입력이 없으면 해당 키워드로 자동완성을 요청 (Places API)~
- SearchView에 `setOnEditorActionListener`메소드를 통해 검색 버튼 클릭 시 현재 입력된 키워드를 가져와 검색 결과가 존재하면 ~해당 위치로 지도 카메라 이동~ RecyclerView로 검색 결과 표시 (Places API)
- SearchView의 검색결과 각 아이템에 클릭리스너를 달아 해당 위치로 지도 카메라 이동하도록 구현
- `Geocoder`의 `getFromLocationName`메소드가 `deprecated`되어, 버전을 나눠 분기 처리

## 고민한 점들(필수 X)
- 검색결과를 어떻게 구현할지 고민하다가, Google Maps에서 Places라는 API를 지원해서 해당 API를 통해 키워드에 대한 주소 검색 결과를 받아옴
- 주소를 받아오는 것은 현재 스레드를 block할 수 있음. 파라미터에 listener가 있는 `getFromLocationName`메소드는 해당 리스너 내에서 검색 결과를 받아와 작업을 하면 해당 문제가 해결되는데, API버전이 33이상이어야 해서 버전에 따른 분기 처리를 해주고, listener가 없는 `getFromLocationName`은 코루틴으로 실행되도록 구현함

## 스크린샷(필수 X)
![ezgif com-video-to-gif (2)](https://github.com/boostcampwm2023/and01-SnapPoint/assets/85796984/8a4a5e0a-f950-4760-9b56-f79d1dfc78f6)
