### PR TITLE
Feature(#40): 현재 위치에서 다시 검색

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
-
 @Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     alias(libs.plugins.androidApplication)
@@ -27,7 +25,6 @@ android {
         versionName = "0.1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        buildConfigField("String", "apiKey", getApiKey("MAPS_API_KEY"))
     }
     signingConfigs {
         create("release") {
@@ -56,16 +53,11 @@ android {
     buildFeatures{
         buildConfig = true
         dataBinding = true
-        buildConfig = true
     }
 
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_17.majorVersion
     }
-}
-
-fun getApiKey(propertyKey: String) : String {
-    return gradleLocalProperties(rootDir, providers).getProperty(propertyKey)
 }
 
 dependencies {

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -339,6 +339,10 @@ class MainActivity :
                     viewModel.updateAutoCompleteTexts(emptyList())
                 }
             }
+
+            btnSearchHere.setOnClickListener {
+                searchSnapPoints()
+            }
         }
     }
 
@@ -390,6 +394,11 @@ class MainActivity :
                     Log.e("TAG", "Place not found: ${exception.statusCode}")
                 }
             }
+    }
+
+    private fun searchSnapPoints() {
+        val latLngBound = googleMap?.projection?.visibleRegion?.latLngBounds ?: return
+        Log.d("TAG", "searchSnapPoints: $latLngBound")
     }
 
     override fun onMapReady(googleMap: GoogleMap) {

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -51,6 +51,18 @@
                     app:navigationIcon="@drawable/icon_drawer"
                     app:menu="@menu/search_view_menu"/>
 
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btn_search_here"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="현재 위치에서 다시 검색"
+                    android:textSize="12sp"
+                    app:layout_anchor="@id/sb"
+                    app:layout_anchorGravity="bottom|center"
+                    android:layout_gravity="bottom|center"
+                    android:translationY="16dp"
+                    android:minHeight="0dp"/>
+
                 <com.google.android.material.appbar.AppBarLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"


### PR DESCRIPTION
## 작업 개요
- [x] 현재 위치에서 다시 검색 버튼을 만들고, 클릭 시 현재 화면의 SouthWest와 NorthEast의 좌표를 Log로 출력

## 작업 사항
- 버튼 클릭 시 `GoogleMap.projection.visibleRegion.latLngBounds`를 통해 현재 지도 화면에 보이는 지역에 대한 정보 중 왼쪽 아래와 오른쪽 위의 좌표를 가져온다.

## 스크린샷(필수 X)
![image](https://github.com/boostcampwm2023/and01-SnapPoint/assets/85796984/3bc71383-bc08-49a9-a6db-9339af7ee1cd)