### PR TITLE
Fix: post-api의 sign-in 임시 처리 제거

### DIFF
--- a/backend/src/api/post-api/post-api.controller.ts
+++ b/backend/src/api/post-api/post-api.controller.ts
@@ -1,5 +1,4 @@
-import { inspect } from 'util';
-import { Body, Controller, Get, Logger, Param, Post, Put, Req, UsePipes } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Put, Req, UsePipes } from '@nestjs/common';
 import { PostApiService } from './post-api.service';
 import { PostRequestDecompositionPipe } from './pipes/post-request-decompositon.pipe';
 import { ComposedPostDto } from './dtos/composed-post.dto';
@@ -28,7 +27,6 @@ export class PostApiController {
   readPosts() {}
 
   @Post('/publish')
-  @NoAuth()
   @UsePipes(PostRequestDecompositionPipe, validationPipe)
   @ApiOperation({
     summary: '게시글을 작성하는 API',
@@ -40,9 +38,8 @@ export class PostApiController {
   })
   @ApiNotFoundResponse({ description: '업로드한 파일 정보를 찾을 수 없습니다.' })
   writePost(@Body() postDto: ComposedPostDto, @Req() request: any) {
-    request;
-    // const { uuid: userUuid } = request.user;
-    return this.postApiService.writePost(postDto, 'c6a7c590-6239-4d12-ad8f-c8065db60d6a');
+    const { uuid: userUuid } = request.user;
+    return this.postApiService.writePost(postDto, userUuid);
   }
 
   @Put('/:uuid')


### PR DESCRIPTION
## 작업 개요
post-api의 sign-in 임시 처리 제거

## 작업 사항
- 타 API와 충돌로 인해 임시로 로그인하는 처리를 제거