### PR TITLE
FIX: 엑세스 토큰 만료시 재발급

### DIFF
--- a/backend/src/api/auth/auth.controller.ts
+++ b/backend/src/api/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, Res, UsePipes, Get } from '@nestjs/common';
+import { Controller, Post, Body, Res, Get } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { CreateAuthDto } from './dto/create-auth.dto';
 import { LoginAuthDto } from './dto/login-auth.dto';
@@ -7,7 +7,6 @@ import { UserService } from '@/domain/user/user.service';
 import { ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { NoAuth } from '@/common/decorator/no-auth.decorator';
 import { Cookies } from '@/common/decorator/cookie.decorator';
-import { validationPipe } from '@/common/pipes/validation.pipe';
 
 @ApiTags('')
 @Controller('')
@@ -49,24 +48,6 @@ export class AuthController {
     });
 
     return loginDto;
-  }
-
-  @Post('refresh')
-  @UsePipes(validationPipe)
-  @NoAuth()
-  @ApiOperation({
-    summary: '엑세스 토큰 재발급 API',
-    description: '새로운 엑세스 토큰을 반환한다.',
-  })
-  @ApiOkResponse({ description: '성공적으로 엑세스 토큰 발급이 완료되었습니다.' })
-  @ApiNotFoundResponse({ description: '해당 리프레시 토큰으로 새로운 엑세스 토큰을 발급할 수 없습니다.' })
-  async refresh(@Cookies('refresh_token') refreshToken: string, @Res({ passthrough: true }) res: Response) {
-    const refreshDto = await this.authService.refresh(refreshToken);
-    res.setHeader('Authorization', 'Bearer ' + refreshDto.accessToken);
-    res.cookie('access_token', refreshDto.accessToken, {
-      httpOnly: true,
-    });
-    return refreshDto;
   }
 
   @Get('logout')

--- a/backend/src/api/auth/auth.module.ts
+++ b/backend/src/api/auth/auth.module.ts
@@ -4,7 +4,7 @@ import { AuthController } from './auth.controller';
 import { PassportModule } from '@nestjs/passport';
 import { JwtModule } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
-import { JwtStrategy } from '../../common/strategies/auth.jwt.strategy';
+import { JwtStrategy } from '@/common/strategies/auth.jwt.strategy';
 import { RefreshTokenService } from '@/domain/refresh-token/refresh-token.service';
 import { UserService } from '@/domain/user/user.service';
 import { PrismaProvider } from '@/common/prisma/prisma.provider';

--- a/backend/src/api/auth/auth.service.spec.ts
+++ b/backend/src/api/auth/auth.service.spec.ts
@@ -12,7 +12,6 @@ import { PrismaService } from '@/common/prisma/prisma.service';
 
 describe('AuthSerivce', () => {
   let service: AuthService;
-  let jwtService: DeepMockProxy<JwtService>;
   let refreshTokenService: DeepMockProxy<RefreshTokenService>;
   let userService: DeepMockProxy<UserService>;
 
@@ -37,7 +36,6 @@ describe('AuthSerivce', () => {
       .compile();
 
     service = module.get<AuthService>(AuthService);
-    jwtService = module.get(JwtService);
     refreshTokenService = module.get(RefreshTokenService);
     userService = module.get(UserService);
   });
@@ -81,42 +79,6 @@ describe('AuthSerivce', () => {
       expect(result).toEqual({
         accessToken: access_token,
         refreshToken: refresh_token,
-      });
-    });
-  });
-
-  describe('refresh', () => {
-    const access_token = 'test_access_token';
-    const refreshToken = 'test_refresh_token';
-    const userMock: User = {
-      id: 1,
-      email: 'test@example.com',
-      password: 'Password123@@',
-      nickname: 'testNickname',
-      uuid: 'testUuid',
-      createdAt: new Date(),
-      modifiedAt: new Date(),
-      isDeleted: false,
-    };
-    const refreshTokenMock: RefreshToken = {
-      id: 0,
-      userUuid: 'testUuid',
-      token: 'testtoken',
-      expiresAt: new Date(),
-      createdAt: new Date(),
-      modifiedAt: new Date(),
-    };
-
-    it('refresh 토큰 검증 이후 access_token을 반환한다.', async () => {
-      jwtService.verifyAsync.mockResolvedValue({ uuid: 'testUuid' });
-      userService.findUserByUniqueInput.mockResolvedValueOnce(userMock);
-      refreshTokenService.generateAccessToken.mockResolvedValueOnce(access_token);
-      refreshTokenService.findRefreshTokenByUnique.mockResolvedValue(refreshTokenMock);
-
-      const result = await service.refresh(refreshToken);
-
-      expect(result).toEqual({
-        accessToken: access_token,
       });
     });
   });

--- a/backend/src/api/auth/auth.service.ts
+++ b/backend/src/api/auth/auth.service.ts
@@ -6,7 +6,6 @@ import { ConfigService } from '@nestjs/config';
 import { RefreshTokenService } from '@/domain/refresh-token/refresh-token.service';
 import { LoginAuthDto } from './dto/login-auth.dto';
 import { LoginDto } from './dto/login.dto';
-import { RefreshDto } from './dto/refresh.dto';
 import { CreateAuthDto } from './dto/create-auth.dto';
 import { SignUpDto } from './dto/signup.dto';
 
@@ -51,30 +50,6 @@ export class AuthService {
     if (!isPasswordMatching) {
       throw new BadRequestException('잘못된 비밀번호입니다.');
     }
-  }
-
-  async refresh(refreshToken: string): Promise<{ accessToken: string }> {
-    const decodedRefreshToken = await this.jwtService.verifyAsync(refreshToken, {
-      secret: this.configService.get<string>('JWT_REFRESH_SECRET'),
-    });
-
-    const refreshTokenEntity = await this.refreshTokenService.findRefreshTokenByUnique({
-      userUuid: decodedRefreshToken.uuid,
-    });
-
-    if (!refreshTokenEntity) {
-      throw new NotFoundException('리프레시 토큰이 존재하지 않습니다.');
-    }
-
-    const user = await this.userService.findUserByUniqueInput({ uuid: refreshTokenEntity.userUuid });
-
-    if (!user) {
-      throw new NotFoundException('해당 유저가 존재하지 않습니다.');
-    }
-
-    const accessToken = await this.refreshTokenService.generateAccessToken(user);
-
-    return RefreshDto.of(accessToken);
   }
 
   async logout(refreshToken: string) {

--- a/backend/src/common/guards/jwt-auth.guard.ts
+++ b/backend/src/common/guards/jwt-auth.guard.ts
@@ -1,4 +1,3 @@
-import { AuthService } from '@/api/auth/auth.service';
 import { RefreshTokenService } from '@/domain/refresh-token/refresh-token.service';
 import { UserService } from '@/domain/user/user.service';
 import {
@@ -22,7 +21,6 @@ export class JwtAuthGuard implements CanActivate {
     private configService: ConfigService,
     private refreshTokenService: RefreshTokenService,
     private userService: UserService,
-    private authSerivce: AuthService,
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<any> {

--- a/backend/src/common/guards/jwt-auth.guard.ts
+++ b/backend/src/common/guards/jwt-auth.guard.ts
@@ -1,4 +1,13 @@
-import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { RefreshTokenService } from '@/domain/refresh-token/refresh-token.service';
+import { UserService } from '@/domain/user/user.service';
+import {
+  BadRequestException,
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  InternalServerErrorException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Reflector } from '@nestjs/core';
 import { JwtService } from '@nestjs/jwt';
@@ -9,7 +18,10 @@ export class JwtAuthGuard implements CanActivate {
     private jwtService: JwtService,
     private reflector: Reflector,
     private configService: ConfigService,
+    private refreshTokenService: RefreshTokenService,
+    private userService: UserService,
   ) {}
+
   async canActivate(context: ExecutionContext): Promise<any> {
     const isPublic = this.reflector.get<boolean>('isPublic', context.getHandler());
 
@@ -17,15 +29,79 @@ export class JwtAuthGuard implements CanActivate {
       return true;
     }
 
+    const request = context.switchToHttp().getRequest();
+
     try {
-      const request = context.switchToHttp().getRequest();
-      const access_token = request.cookies['access_token'];
-      const user = await this.jwtService.verifyAsync(access_token, {
+      const accessToken = request.cookies['access_token'];
+
+      if (!accessToken) {
+        throw new BadRequestException('엑세스 토큰이 존재하지 않습니다.');
+      }
+
+      const user = await this.jwtService.verifyAsync(accessToken, {
         secret: this.configService.get<string>('JWT_ACCESS_SECRET'),
       });
+
       request.user = user;
+
       return true;
     } catch (err) {
+      if (err instanceof BadRequestException) {
+        throw err;
+      }
+      if (!err || err.name !== 'TokenExpiredError') {
+        throw new InternalServerErrorException();
+      }
+
+      const refreshToken = request.cookies['refresh_token'];
+
+      if (!refreshToken) {
+        throw new BadRequestException('리프레시 토큰이 존재하지 않습니다.');
+      }
+
+      return this.checkRefreshToken(context, refreshToken);
+    }
+  }
+
+  async checkRefreshToken(context: ExecutionContext, refreshToken: string) {
+    try {
+      const decoded = await this.jwtService.verifyAsync(refreshToken, {
+        secret: this.configService.get<string>('JWT_REFRESH_SECRET'),
+      });
+
+      const refreshTokenEntity = await this.refreshTokenService.findRefreshTokenByUnique({
+        userUuid: decoded.uuid,
+      });
+
+      if (!refreshTokenEntity) {
+        throw new UnauthorizedException('해당 리프레시 토큰이 존재하지 않습니다.');
+      }
+
+      const user = await this.userService.findUserByUniqueInput({
+        uuid: refreshTokenEntity.userUuid,
+      });
+
+      if (!user) {
+        throw new UnauthorizedException();
+      }
+
+      const newAccessToken = await this.refreshTokenService.generateAccessToken(user);
+
+      context.switchToHttp().getRequest().user = decoded;
+
+      const res = context.switchToHttp().getResponse();
+      res.setHeader('Authorization', 'Bearer ' + [newAccessToken, refreshToken]);
+      res.cookie('access_token', newAccessToken, {
+        httpOnly: true,
+      });
+      res.cookie('refresh_token', refreshToken, {
+        httpOnly: true,
+      });
+      return true;
+    } catch (refreshTokenError) {
+      if (refreshTokenError.name === 'TokenExpiredError') {
+        throw new UnauthorizedException('리프레시 토큰이 만료되었습니다.');
+      }
       return false;
     }
   }

--- a/backend/src/common/strategies/auth.jwt.strategy.ts
+++ b/backend/src/common/strategies/auth.jwt.strategy.ts
@@ -11,9 +11,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     readonly configService: ConfigService,
   ) {
     super({
-      // Authorization에서 Bearer Token에 JWT 토큰을 담아 전송
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
-      // Passport에 검증 위임
       ignoreExpiration: false,
       secretOrKey: configService.get<string>('JWT_ACCESS_SECRET'),
     });

--- a/backend/src/domain/refresh-token/refresh-token.service.ts
+++ b/backend/src/domain/refresh-token/refresh-token.service.ts
@@ -63,9 +63,11 @@ export class RefreshTokenService {
   async generateAccessToken(user: User): Promise<string> {
     const payload = {
       uuid: user.uuid,
-      email: user.email,
     };
-    return await this.jwtService.signAsync(payload);
+    return await this.jwtService.signAsync(payload, {
+      secret: this.configService.get<string>('JWT_ACCESS_SECRET'),
+      expiresIn: this.configService.get<string>('JWT_ACCESS_EXPIRATION_TIME'),
+    });
   }
 
   async generateRefreshToken(user: User): Promise<string> {


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): 화면 UI 그리기 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
- 엑세스 토큰 만료시 자동 재발급 구현
- 
## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- 엑세스 토큰 만료시 자동 재발급 구현
  - `authGuard`에서 재발급하도록 수정
- `authController`, `authService` 리프레시 로직 제거

- 리프레시 토큰 만료시 에러 처리
```json
{
    "message": "리프레시 토큰이 만료되었습니다.",
    "error": "Unauthorized",
    "statusCode": 401
}
```
## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->