### PR TITLE
FIX: MainUiState가 업데이트 될 때 불필요한 UI도 업데이트 되는 문제 수정

### DIFF
--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/around/AroundFragment.kt
@@ -32,8 +32,8 @@ class AroundFragment : BaseFragment<FragmentAroundBinding>(R.layout.fragment_aro
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 launch {
-                    mainViewModel.uiState.collect {
-                        aroundViewModel.updatePosts(it.posts)
+                    mainViewModel.postState.collect {
+                        aroundViewModel.updatePosts(it)
                     }
                 }
                 launch {

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -182,7 +182,6 @@ class MainActivity :
                     var drawnRoute: Polyline? = null
                     var prevSelectedIndex = -1
                     viewModel.uiState.collect { uiState ->
-//                        updateMarker(uiState.snapPoints)
                         if (uiState.selectedIndex < 0 || uiState.focusedIndex < 0) {
                             prevSelectedMarker?.remove()
                             drawnRoute?.remove()
@@ -191,9 +190,6 @@ class MainActivity :
                         }
                         val block = viewModel.postState.value[uiState.selectedIndex].postBlocks
                             .filterIsInstance<PostBlockState.IMAGE>()[uiState.focusedIndex]
-//                        val selectedMarker =
-//                            uiState.snapPoints[uiState.selectedIndex].markers[uiState.focusedIndex]
-//                                ?: return@collect
 
                         prevSelectedMarker?.remove()
                         prevSelectedMarker = googleMap?.addImageMarker(
@@ -214,7 +210,7 @@ class MainActivity :
                     viewModel.postState.collect { postState ->
                         while (googleMap == null) { delay(100) }
 
-                        val snapPoints = postState.mapIndexed { postIndex, postSummaryState ->
+                        postState.forEachIndexed { postIndex, postSummaryState ->
                             SnapPointState(
                                 index = postIndex,
                                 markers = postSummaryState.postBlocks.filterIsInstance<PostBlockState.IMAGE>().mapIndexed { pointIndex, postBlockState ->
@@ -228,37 +224,6 @@ class MainActivity :
                                 }
                             )
                         }
-                        viewModel.createMarkers(snapPoints)
-                    }
-                }
-            }
-        }
-    }
-
-    private fun updateMarker(snapPoints: List<SnapPointState>) {
-        lifecycleScope.launch {
-            while (googleMap == null) {
-                delay(100)
-            }
-            val selectedIndex = viewModel.uiState.value.selectedIndex
-            googleMap?.let { map ->
-                map.clear()
-                snapPoints.forEachIndexed { postIndex, snapPointState ->
-                    if(postIndex == selectedIndex){
-                        drawRoutes(selectedIndex)
-                    }
-                    val mediaBlock = viewModel.postState.value[postIndex].postBlocks
-                        .filterIsInstance<PostBlockState.IMAGE>()
-                    snapPointState.markers.forEachIndexed { snapPointIndex, marker ->
-                        val focused =
-                            (postIndex == viewModel.uiState.value.selectedIndex) && (snapPointIndex == viewModel.uiState.value.focusedIndex)
-//                        map.addImageMarker(
-//                            context = this@MainActivity,
-//                            markerOptions = marker,
-//                            uri = mediaBlock[snapPointIndex].content,
-//                            tag = SnapPointTag(postIndex = postIndex, snapPointIndex = snapPointIndex),
-//                            focused = focused
-//                        )
                     }
                 }
             }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -174,9 +174,16 @@ class MainActivity :
                         }
                     }
                 }
+
                 launch {
                     viewModel.uiState.collect { uiState ->
                         updateMarker(uiState.snapPoints)
+                    }
+                }
+
+                launch {
+                    viewModel.postState.collect {
+                        viewModel.createMarkers()
                     }
                 }
             }
@@ -195,7 +202,7 @@ class MainActivity :
                     if(postIndex == selectedIndex){
                         drawRoutes(selectedIndex)
                     }
-                    val mediaBlock = viewModel.uiState.value.posts[postIndex].postBlocks
+                    val mediaBlock = viewModel.postState.value[postIndex].postBlocks
                         .filterIsInstance<PostBlockState.IMAGE>()
                     snapPointState.markerOptions.forEachIndexed { snapPointIndex, markerOptions ->
                         val focused =
@@ -215,7 +222,7 @@ class MainActivity :
 
     private fun drawRoutes(postIndex: Int) {
         val polylineOptions = PolylineOptions().color(getColor(R.color.error80)).width(3.pxFloat()).pattern(listOf(Dash(20f), Gap(20f)))
-        val positionList = viewModel.uiState.value.posts[postIndex].postBlocks.filterNot { it is PostBlockState.TEXT }.map{ block ->
+        val positionList = viewModel.postState.value[postIndex].postBlocks.filterNot { it is PostBlockState.TEXT }.map{ block ->
             when (block) {
                 is PostBlockState.IMAGE -> {
                     LatLng(block.position.latitude, block.position.longitude)

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainActivity.kt
@@ -413,7 +413,8 @@ class MainActivity :
     private fun checkPermissionAndMoveCameraToUserLocation() {
         if(this.isMyLocationGranted()){
             fusedLocationClient.lastLocation
-                .addOnSuccessListener {location ->
+                .addOnSuccessListener { location ->
+                    location ?: return@addOnSuccessListener
                     googleMap?.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(location.latitude, location.longitude),17.5f))
                 }
         }else{
@@ -433,7 +434,7 @@ class MainActivity :
         fusedLocationClient.requestLocationUpdates(LocationRequest.Builder(1000L).build(),
             locationCallback,
             Looper.getMainLooper()
-            )
+        )
     }
 
     override fun onRequestPermissionsResult(

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainUiState.kt
@@ -1,11 +1,10 @@
 package com.boostcampwm2023.snappoint.presentation.main
 
 import com.google.android.gms.maps.model.Marker
-import com.google.android.gms.maps.model.MarkerOptions
 
 data class MainUiState(
 //    val posts: List<PostSummaryState> = emptyList(),
-    val snapPoints: List<SnapPointState> = emptyList(),
+//    val snapPoints: List<SnapPointState> = emptyList(),
     val selectedIndex: Int = -1,
     val focusedIndex: Int = -1,
     val isPreviewFragmentShowing: Boolean = false,

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainUiState.kt
@@ -4,7 +4,7 @@ import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
 import com.google.android.gms.maps.model.MarkerOptions
 
 data class MainUiState(
-    val posts: List<PostSummaryState> = emptyList(),
+//    val posts: List<PostSummaryState> = emptyList(),
     val snapPoints: List<SnapPointState> = emptyList(),
     val selectedIndex: Int = -1,
     val focusedIndex: Int = -1,

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainUiState.kt
@@ -1,6 +1,6 @@
 package com.boostcampwm2023.snappoint.presentation.main
 
-import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
+import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.MarkerOptions
 
 data class MainUiState(
@@ -15,5 +15,5 @@ data class MainUiState(
 data class SnapPointState(
     //todo 게시물의 고유 번호로 변경
     val index: Int,
-    val markerOptions: List<MarkerOptions>
+    val markers: List<Marker?>
 )

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainUiState.kt
@@ -3,10 +3,8 @@ package com.boostcampwm2023.snappoint.presentation.main
 import com.google.android.gms.maps.model.Marker
 
 data class MainUiState(
-//    val posts: List<PostSummaryState> = emptyList(),
-//    val snapPoints: List<SnapPointState> = emptyList(),
-    val selectedIndex: Int = -1,
-    val focusedIndex: Int = -1,
+    val selectedIndex: Int = -1,    // TODO - MarkerUiState 로 옮기기
+    val focusedIndex: Int = -1,     // TODO - MarkerUiState 로 옮기기
     val isPreviewFragmentShowing: Boolean = false,
     val isBottomSheetExpanded: Boolean = false,
 )

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
@@ -126,7 +126,7 @@ class MainViewModel @Inject constructor(
     }
 
     fun createMarkers(snapPoints: List<SnapPointState>) {
-        _uiState.update {
+//        _uiState.update {
 //            it.copy(snapPoints = _postState.value.mapIndexed { index, postSummaryState ->
 //                SnapPointState(
 //                    index = index,
@@ -137,8 +137,8 @@ class MainViewModel @Inject constructor(
 //                    }
 //                )
 //            })
-            it.copy(snapPoints = snapPoints)
-        }
+//            it.copy(snapPoints = snapPoints)
+//        }
     }
 
     fun drawerIconClicked() {

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
@@ -125,21 +125,19 @@ class MainViewModel @Inject constructor(
 //        createMarkers()
     }
 
-    fun createMarkers() {
+    fun createMarkers(snapPoints: List<SnapPointState>) {
         _uiState.update {
-            it.copy(
-                snapPoints =
-                _postState.value.mapIndexed { index, postSummaryState ->
-                    SnapPointState(
-                        index = index,
-                        markerOptions = postSummaryState.postBlocks.filterIsInstance<PostBlockState.IMAGE>().map {
-                            MarkerOptions().apply {
-                                position(it.position.asLatLng())
-                            }
-                        }
-                    )
-                }
-            )
+//            it.copy(snapPoints = _postState.value.mapIndexed { index, postSummaryState ->
+//                SnapPointState(
+//                    index = index,
+//                    markers = postSummaryState.postBlocks.filterIsInstance<PostBlockState.IMAGE>().map {
+//                        MarkerOptions().apply {
+//                            position(it.position.asLatLng())
+//                        }
+//                    }
+//                )
+//            })
+            it.copy(snapPoints = snapPoints)
         }
     }
 

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
@@ -7,7 +7,6 @@ import com.boostcampwm2023.snappoint.presentation.model.PositionState
 import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
 import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
 import com.boostcampwm2023.snappoint.presentation.model.SnapPointTag
-import com.google.android.gms.maps.model.MarkerOptions
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -122,23 +121,6 @@ class MainViewModel @Inject constructor(
                 ),
             )
         }
-//        createMarkers()
-    }
-
-    fun createMarkers(snapPoints: List<SnapPointState>) {
-//        _uiState.update {
-//            it.copy(snapPoints = _postState.value.mapIndexed { index, postSummaryState ->
-//                SnapPointState(
-//                    index = index,
-//                    markers = postSummaryState.postBlocks.filterIsInstance<PostBlockState.IMAGE>().map {
-//                        MarkerOptions().apply {
-//                            position(it.position.asLatLng())
-//                        }
-//                    }
-//                )
-//            })
-//            it.copy(snapPoints = snapPoints)
-//        }
     }
 
     fun drawerIconClicked() {

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
@@ -24,6 +24,8 @@ class MainViewModel @Inject constructor(
     private val postRepository: PostRepository
 ) :ViewModel(){
 
+    private val _postState: MutableStateFlow<List<PostSummaryState>> = MutableStateFlow(emptyList())
+    val postState: StateFlow<List<PostSummaryState>> = _postState.asStateFlow()
 
     private val _uiState: MutableStateFlow<MainUiState> = MutableStateFlow(MainUiState())
     val uiState: StateFlow<MainUiState> = _uiState.asStateFlow()
@@ -48,86 +50,86 @@ class MainViewModel @Inject constructor(
     }
 
     private fun loadPosts() {
-        _uiState.update {
-            MainUiState(
-                posts = listOf(
-                    PostSummaryState(
-                        title = "하이",
-                        author = "원승빈",
-                        timeStamp = "2 Days Ago",
-                        postBlocks = listOf(
-                            PostBlockState.TEXT(
-                                content = "안녕하세요, 하하"
-                            ),
-                            PostBlockState.IMAGE(
-                                content = "https://health.chosun.com/site/data/img_dir/2023/07/17/2023071701753_0.jpg",
-                                position = PositionState(37.421793077676774, -122.09180117366115),
-                                description = "고양이입니다.",
-                                address = "null"
-                            ),PostBlockState.IMAGE(
-                                content = "https://pds.joongang.co.kr/news/component/htmlphoto_mmdata/201901/20/28017477-0365-4a43-b546-008b603da621.jpg",
-                                position = PositionState(37.41887606344049, -122.0879954078449),
-                                description = "강아징입니다.",
-                                address = "null"
-                            ),
-                            PostBlockState.TEXT(
-                                content = "ㅎㅇ염"
-                            ),PostBlockState.TEXT(
-                                content = "동물원갔다왔슴다 ㅋ"
-                            ),
-                            PostBlockState.IMAGE(
-                                content = "https://i.namu.wiki/i/Nvsy3_i1lyInOB79UBbcDeR6MocJ4C8TBN8NjepPwqTnojCbb3Xwge9gQXfAGgW74ZA3c3i16odhBLE0bSwgFA.webp",
-                                position = PositionState(37.42155682099068, -122.08342886715077),
-                                description = "이것은 악어~",
-                                address = "null"
-                            ),
-                            PostBlockState.IMAGE(
-                                content = "https://upload.wikimedia.org/wikipedia/commons/4/41/Siberischer_tiger_de_edit02.jpg",
-                                position = PositionState(37.4227919844394, -122.08028507548029),
-                                description = "어흥",
-                                address = "null"
-                            ),
-                        )
-                    ),
-                    PostSummaryState(
-                        title = "여름 철새 구경",
-                        author = "익명",
-                        timeStamp = "3 Weeks Ago",
-                        postBlocks = listOf(
-                            PostBlockState.TEXT(
-                                content = "123"
-                            ),
-                            PostBlockState.IMAGE(
-                                content = "https://upload.wikimedia.org/wikipedia/commons/8/85/Columbina_passerina.jpg",
-                                position = PositionState(37.40837052881207, -122.10293026989889),
-                                description = "비둘기야 먹자 구구구구",
-                                address = "address"
-                            ),
-                            PostBlockState.IMAGE(
-                                content = "https://upload.wikimedia.org/wikipedia/commons/f/f0/Nipponia_nippon_20091230131054.png",
-                                position = PositionState(37.40272239693208, -122.06577824456974),
-                                description = "떴따 오기",
-                                address = "address"
-                            ),
-                            PostBlockState.IMAGE(
-                                content = "https://upload.wikimedia.org/wikipedia/commons/8/82/Watercock_%28Gallicrex_cinerea%29.jpg",
-                                position = PositionState(37.414911773823924, -122.0536102126485),
-                                description = "뜸 부기",
-                                address = "address"
-                            ),
-                        )
-                    ),
-                )
+        _postState.update {
+            listOf(
+                PostSummaryState(
+                    title = "하이",
+                    author = "원승빈",
+                    timeStamp = "2 Days Ago",
+                    postBlocks = listOf(
+                        PostBlockState.TEXT(
+                            content = "안녕하세요, 하하"
+                        ),
+                        PostBlockState.IMAGE(
+                            content = "https://health.chosun.com/site/data/img_dir/2023/07/17/2023071701753_0.jpg",
+                            position = PositionState(37.421793077676774, -122.09180117366115),
+                            description = "고양이입니다.",
+                            address = "null"
+                        ),
+                        PostBlockState.IMAGE(
+                            content = "https://pds.joongang.co.kr/news/component/htmlphoto_mmdata/201901/20/28017477-0365-4a43-b546-008b603da621.jpg",
+                            position = PositionState(37.41887606344049, -122.0879954078449),
+                            description = "강아징입니다.",
+                            address = "null"
+                        ),
+                        PostBlockState.TEXT(
+                            content = "ㅎㅇ염"
+                        ),
+                        PostBlockState.TEXT(
+                            content = "동물원갔다왔슴다 ㅋ"
+                        ),
+                        PostBlockState.IMAGE(
+                            content = "https://i.namu.wiki/i/Nvsy3_i1lyInOB79UBbcDeR6MocJ4C8TBN8NjepPwqTnojCbb3Xwge9gQXfAGgW74ZA3c3i16odhBLE0bSwgFA.webp",
+                            position = PositionState(37.42155682099068, -122.08342886715077),
+                            description = "이것은 악어~",
+                            address = "null"
+                        ),
+                        PostBlockState.IMAGE(
+                            content = "https://upload.wikimedia.org/wikipedia/commons/4/41/Siberischer_tiger_de_edit02.jpg",
+                            position = PositionState(37.4227919844394, -122.08028507548029),
+                            description = "어흥",
+                            address = "null"
+                        ),
+                    )
+                ),
+                PostSummaryState(
+                    title = "여름 철새 구경",
+                    author = "익명",
+                    timeStamp = "3 Weeks Ago",
+                    postBlocks = listOf(
+                        PostBlockState.TEXT(
+                            content = "123"
+                        ),
+                        PostBlockState.IMAGE(
+                            content = "https://upload.wikimedia.org/wikipedia/commons/8/85/Columbina_passerina.jpg",
+                            position = PositionState(37.40837052881207, -122.10293026989889),
+                            description = "비둘기야 먹자 구구구구",
+                            address = "address"
+                        ),
+                        PostBlockState.IMAGE(
+                            content = "https://upload.wikimedia.org/wikipedia/commons/f/f0/Nipponia_nippon_20091230131054.png",
+                            position = PositionState(37.40272239693208, -122.06577824456974),
+                            description = "떴따 오기",
+                            address = "address"
+                        ),
+                        PostBlockState.IMAGE(
+                            content = "https://upload.wikimedia.org/wikipedia/commons/8/82/Watercock_%28Gallicrex_cinerea%29.jpg",
+                            position = PositionState(37.414911773823924, -122.0536102126485),
+                            description = "뜸 부기",
+                            address = "address"
+                        ),
+                    )
+                ),
             )
         }
-        createMarkers()
+//        createMarkers()
     }
 
-    private fun createMarkers() {
+    fun createMarkers() {
         _uiState.update {
             it.copy(
                 snapPoints =
-                _uiState.value.posts.mapIndexed { index, postSummaryState ->
+                _postState.value.mapIndexed { index, postSummaryState ->
                     SnapPointState(
                         index = index,
                         markerOptions = postSummaryState.postBlocks.filterIsInstance<PostBlockState.IMAGE>().map {

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MarkerUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MarkerUiState.kt
@@ -1,0 +1,6 @@
+package com.boostcampwm2023.snappoint.presentation.main
+
+data class MarkerUiState(
+    val selectedIndex: Int = -1,
+    val focusedIndex: Int = -1,
+)

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/mainbindingAdapter.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/mainbindingAdapter.kt
@@ -1,6 +1,5 @@
 package com.boostcampwm2023.snappoint.presentation.main
 
-import android.annotation.SuppressLint
 import android.widget.LinearLayout
 import androidx.databinding.BindingAdapter
 import com.boostcampwm2023.snappoint.R

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/preview/PreviewFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/preview/PreviewFragment.kt
@@ -68,7 +68,7 @@ class PreviewFragment : BaseFragment<FragmentPreviewBinding>(R.layout.fragment_p
             repeatOnLifecycle(Lifecycle.State.RESUMED){
                 mainViewModel.uiState.collect{
                     if (it.selectedIndex > -1) {
-                        previewViewModel.updatePost(it.posts[it.selectedIndex])
+                        previewViewModel.updatePost(mainViewModel.postState.value[it.selectedIndex])
                     }
                     moveScroll(it.focusedIndex)
                 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/util/SnapPointUtil.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/util/SnapPointUtil.kt
@@ -15,6 +15,7 @@ import com.boostcampwm2023.snappoint.R
 import com.boostcampwm2023.snappoint.presentation.model.SnapPointTag
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
+import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.MarkerOptions
 
 
@@ -24,7 +25,7 @@ suspend fun GoogleMap.addImageMarker(
     uri: String,
     tag: SnapPointTag,
     focused: Boolean,
-){
+): Marker? {
 
     val request = ImageRequest.Builder(context)
         .data(uri)
@@ -51,7 +52,7 @@ suspend fun GoogleMap.addImageMarker(
 
     val snapPoint = mergeToSnapPointBitmap(listOf(snapPointUnFocused, container, userImage))
 
-    this.addMarker(markerOptions.icon(
+    return this.addMarker(markerOptions.icon(
         BitmapDescriptorFactory.fromBitmap(
             snapPoint
         )


### PR DESCRIPTION
## 작업 개요
- [x] UiState가 업데이트 될 때 모든 marker가 다시 그려지는 문제를 해결

## 작업 사항
- marker를 map에 추가할 때 해당 marker를 반환하는데, 이를 이용해 선택된 스냅포인트를 그릴 때 해당 marker를 보관해뒀다가 선택이 바뀔 때 보관했던 marker를 remove() 로 지도에서 제거하고, 새로 그린 마커를 다시 보관하도록 하여 모든 marker가 다시 그려지는 문제를 해결