### PR TITLE
Feature(#216): 게시글 로컬에 저장

### DIFF
--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/local/PostDatabase.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/local/PostDatabase.kt
@@ -2,10 +2,13 @@ package com.boostcampwm2023.snappoint.data.local
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import com.boostcampwm2023.snappoint.data.local.converter.PostTypeConverter
 import com.boostcampwm2023.snappoint.data.local.dao.PostDao
 import com.boostcampwm2023.snappoint.data.local.entity.SerializedPost
 
 @Database(entities = [SerializedPost::class], version = 1)
+@TypeConverters(PostTypeConverter::class)
 abstract class PostDatabase: RoomDatabase() {
     abstract fun getPostDao(): PostDao
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/local/PostDatabase.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/local/PostDatabase.kt
@@ -1,0 +1,11 @@
+package com.boostcampwm2023.snappoint.data.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import com.boostcampwm2023.snappoint.data.local.dao.PostDao
+import com.boostcampwm2023.snappoint.data.local.entity.SerializedPost
+
+@Database(entities = [SerializedPost::class], version = 1)
+abstract class PostDatabase: RoomDatabase() {
+    abstract fun getPostDao(): PostDao
+}

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/local/converter/PostTypeConverter.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/local/converter/PostTypeConverter.kt
@@ -1,0 +1,20 @@
+package com.boostcampwm2023.snappoint.data.local.converter
+
+import androidx.room.TypeConverter
+import com.boostcampwm2023.snappoint.data.local.entity.SerializedPost
+import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+object PostTypeConverter {
+
+    @TypeConverter
+    fun serialize(post: PostSummaryState): String {
+        return Json.encodeToString(post)
+    }
+
+    @TypeConverter
+    fun deserialize(json: String): PostSummaryState {
+        return Json.decodeFromString(json)
+    }
+}

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/local/dao/PostDao.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/local/dao/PostDao.kt
@@ -1,0 +1,18 @@
+package com.boostcampwm2023.snappoint.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.boostcampwm2023.snappoint.data.local.entity.SerializedPost
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface PostDao {
+
+    @Query("SELECT * FROM postTable")
+    fun getAllPosts() : Flow<List<SerializedPost>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insertPost(vararg posts: SerializedPost)
+}

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/local/entity/SerializedPost.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/local/entity/SerializedPost.kt
@@ -1,0 +1,15 @@
+package com.boostcampwm2023.snappoint.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
+import kotlinx.serialization.Serializable
+
+@Entity(tableName = "postTable")
+@Serializable
+data class SerializedPost(
+    @PrimaryKey
+    @ColumnInfo(name = "post")
+    val post: PostSummaryState
+)

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/local/entity/SerializedPost.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/local/entity/SerializedPost.kt
@@ -10,6 +10,8 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class SerializedPost(
     @PrimaryKey
+    @ColumnInfo(name = "uuid")
+    val uuid: String,
     @ColumnInfo(name = "post")
     val post: PostSummaryState
 )

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/mapper/PostMapper.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/mapper/PostMapper.kt
@@ -5,6 +5,7 @@ import com.boostcampwm2023.snappoint.data.remote.model.File
 import com.boostcampwm2023.snappoint.data.remote.model.PostBlock
 import com.boostcampwm2023.snappoint.data.remote.model.response.GetPostResponse
 import com.boostcampwm2023.snappoint.presentation.model.PositionState
+import com.boostcampwm2023.snappoint.presentation.model.PostBlockCreationState
 import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
 import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
 
@@ -38,15 +39,15 @@ fun PostBlock.asPostBlockState(): PostBlockState {
     }
 }
 
-fun PostBlockState.asPostBlock(): PostBlock {
+fun PostBlockCreationState.asPostBlock(): PostBlock {
     return when(this){
-        is PostBlockState.TEXT -> {
+        is PostBlockCreationState.TEXT -> {
             PostBlock(
                 type = BlockType.TEXT.type,
                 content = this.content,
             )
         }
-        is PostBlockState.IMAGE -> {
+        is PostBlockCreationState.IMAGE -> {
             PostBlock(
                 content = this.description,
                 type = BlockType.MEDIA.type,
@@ -55,7 +56,7 @@ fun PostBlockState.asPostBlock(): PostBlock {
                 files = listOf(File(fileUuid = "this is file's uuid")),
             )
         }
-        is PostBlockState.VIDEO -> {
+        is PostBlockCreationState.VIDEO -> {
             PostBlock(
                 content = this.description,
                 type = BlockType.MEDIA.type,

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/repository/PostRepository.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/repository/PostRepository.kt
@@ -1,7 +1,8 @@
 package com.boostcampwm2023.snappoint.data.repository
 
 import com.boostcampwm2023.snappoint.data.remote.model.response.CreatePostResponse
-import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
+import com.boostcampwm2023.snappoint.presentation.model.PostBlockCreationState
+import com.boostcampwm2023.snappoint.presentation.model.PostCreationState
 import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
 import kotlinx.coroutines.flow.Flow
 
@@ -10,7 +11,7 @@ interface PostRepository {
     fun getImageUri(image: ByteArray): Flow<Unit>
     fun getVideo(uri: String): Flow<ByteArray>
     fun getVideoUri(video: ByteArray): Flow<Unit>
-    fun postCreatePost(title: String, postBlocks: List<PostBlockState>): Flow<CreatePostResponse>
+    fun postCreatePost(title: String, postBlocks: List<PostBlockCreationState>): Flow<CreatePostResponse>
     fun getAroundPost(leftBottom: String, rightTop: String): Flow<List<PostSummaryState>>
     fun getPost(uuid: String): Flow<PostSummaryState>
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/repository/PostRepositoryImpl.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/repository/PostRepositoryImpl.kt
@@ -8,6 +8,8 @@ import com.boostcampwm2023.snappoint.data.remote.model.request.CreatePostRequest
 import com.boostcampwm2023.snappoint.data.remote.model.response.CreatePostResponse
 import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
 import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
+import com.boostcampwm2023.snappoint.presentation.model.PostBlockCreationState
+import com.boostcampwm2023.snappoint.presentation.model.PostCreationState
 import com.boostcampwm2023.snappoint.presentation.util.toByteArray
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
@@ -48,7 +50,7 @@ class PostRepositoryImpl @Inject constructor(
             }
     }
 
-    override fun postCreatePost(title: String, postBlocks: List<PostBlockState>): Flow<CreatePostResponse> {
+    override fun postCreatePost(title: String, postBlocks: List<PostBlockCreationState>): Flow<CreatePostResponse> {
 
         return flowOf(true)
             .map{
@@ -56,7 +58,7 @@ class PostRepositoryImpl @Inject constructor(
                     title = title,
                     postBlocks = postBlocks.map {
                         when (it) {
-                            is PostBlockState.IMAGE -> {
+                            is PostBlockCreationState.IMAGE -> {
                                 val requestBody = it.bitmap?.toByteArray()?.toRequestBody("image/webp".toMediaType())!!
                                 val multipartBody = MultipartBody.Part.createFormData("file", "image", requestBody)
                                 val uploadResult = snapPointApi.postImage(multipartBody)

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/repository/RoomRepository.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/repository/RoomRepository.kt
@@ -1,0 +1,10 @@
+package com.boostcampwm2023.snappoint.data.repository
+
+import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
+import kotlinx.coroutines.flow.Flow
+
+interface RoomRepository {
+
+    fun getLocalPosts(): Flow<List<PostSummaryState>>
+    suspend fun insertPosts(postSummaryState: PostSummaryState)
+}

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/repository/RoomRepositoryImpl.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/repository/RoomRepositoryImpl.kt
@@ -20,7 +20,9 @@ class RoomRepositoryImpl @Inject constructor(
             }
     }
 
-    override suspend fun insertPosts(postSummaryState: PostSummaryState) {
-        localPostDao.insertPost(SerializedPost(postSummaryState))
+    override suspend fun insertPosts(post: PostSummaryState) {
+        localPostDao.insertPost(
+            SerializedPost(post.uuid, post)
+        )
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/repository/RoomRepositoryImpl.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/repository/RoomRepositoryImpl.kt
@@ -1,0 +1,26 @@
+package com.boostcampwm2023.snappoint.data.repository
+
+import com.boostcampwm2023.snappoint.data.local.dao.PostDao
+import com.boostcampwm2023.snappoint.data.local.entity.SerializedPost
+import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class RoomRepositoryImpl @Inject constructor(
+    private val localPostDao: PostDao
+) : RoomRepository {
+
+    override fun getLocalPosts(): Flow<List<PostSummaryState>> {
+        return localPostDao.getAllPosts()
+            .map { serializedPosts ->
+                serializedPosts.map { serializedPost ->
+                    serializedPost.post
+                }
+            }
+    }
+
+    override suspend fun insertPosts(postSummaryState: PostSummaryState) {
+        localPostDao.insertPost(SerializedPost(postSummaryState))
+    }
+}

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/di/RepositoryModule.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/di/RepositoryModule.kt
@@ -1,19 +1,29 @@
 package com.boostcampwm2023.snappoint.di
 
+import com.boostcampwm2023.snappoint.data.local.dao.PostDao
 import com.boostcampwm2023.snappoint.data.repository.SignInRepository
 import com.boostcampwm2023.snappoint.data.repository.SignInRepositoryImpl
 import com.boostcampwm2023.snappoint.data.repository.PostRepository
 import com.boostcampwm2023.snappoint.data.repository.PostRepositoryImpl
+import com.boostcampwm2023.snappoint.data.repository.RoomRepository
+import com.boostcampwm2023.snappoint.data.repository.RoomRepositoryImpl
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
 
 @Module
 @InstallIn(SingletonComponent::class)
 object RepositoryModule {
 
+    @Provides
+    @Singleton
+    fun provideRoomRepository(postDao: PostDao): RoomRepository {
+        return RoomRepositoryImpl(postDao)
+    }
 }
 
 @Module

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/di/RoomModule.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/di/RoomModule.kt
@@ -1,0 +1,41 @@
+package com.boostcampwm2023.snappoint.di
+
+import android.content.Context
+import androidx.room.Room
+import com.boostcampwm2023.snappoint.data.local.PostDatabase
+import com.boostcampwm2023.snappoint.data.local.dao.PostDao
+import com.boostcampwm2023.snappoint.data.repository.RoomRepository
+import com.boostcampwm2023.snappoint.data.repository.RoomRepositoryImpl
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object RoomModule {
+
+    @Provides
+    @Singleton
+    fun providePostDatabase(@ApplicationContext context: Context): PostDatabase {
+        return Room.databaseBuilder(
+            context,
+            PostDatabase::class.java,
+            "database"
+        ).build()
+    }
+
+    @Provides
+    @Singleton
+    fun providePostDao(postDatabase: PostDatabase): PostDao {
+        return postDatabase.getPostDao()
+    }
+
+    @Provides
+    @Singleton
+    fun provideRoomRepository(postDao: PostDao): RoomRepository {
+        return RoomRepositoryImpl(postDao)
+    }
+}

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/di/RoomModule.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/di/RoomModule.kt
@@ -23,7 +23,7 @@ object RoomModule {
         return Room.databaseBuilder(
             context,
             PostDatabase::class.java,
-            "database"
+            "database0"
         ).build()
     }
 

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/di/RoomModule.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/di/RoomModule.kt
@@ -32,10 +32,4 @@ object RoomModule {
     fun providePostDao(postDatabase: PostDatabase): PostDao {
         return postDatabase.getPostDao()
     }
-
-    @Provides
-    @Singleton
-    fun provideRoomRepository(postDao: PostDao): RoomRepository {
-        return RoomRepositoryImpl(postDao)
-    }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/BlockItemViewHolder.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/BlockItemViewHolder.kt
@@ -11,7 +11,7 @@ import androidx.recyclerview.widget.RecyclerView
 import coil.load
 import com.boostcampwm2023.snappoint.databinding.ItemImageBlockBinding
 import com.boostcampwm2023.snappoint.databinding.ItemTextBlockBinding
-import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
+import com.boostcampwm2023.snappoint.presentation.model.PostBlockCreationState
 import com.boostcampwm2023.snappoint.presentation.util.resizeBitmap
 import com.google.android.material.card.MaterialCardView
 
@@ -30,7 +30,7 @@ sealed class BlockItemViewHolder(
         private val blockItemEvent: BlockItemEventListener,
     ) : BlockItemViewHolder(binding, blockItemEvent) {
 
-        fun bind(block: PostBlockState.TEXT, index: Int) {
+        fun bind(block: PostBlockCreationState.TEXT, index: Int) {
             with(binding) {
                 tilText.editText?.setText(block.content)
                 btnDeleteBlock.setOnClickListener { blockItemEvent.onDeleteButtonClick(index) }
@@ -66,7 +66,7 @@ sealed class BlockItemViewHolder(
         private val blockItemEvent: BlockItemEventListener,
     ) : BlockItemViewHolder(binding, blockItemEvent) {
 
-        fun bind(block: PostBlockState.IMAGE, index: Int) {
+        fun bind(block: PostBlockCreationState.IMAGE, index: Int) {
             with(binding) {
                 tilDescription.editText?.setText(block.content)
                 tilAddress.editText?.setText(block.address)

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostListAdapter.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostListAdapter.kt
@@ -6,17 +6,17 @@ import androidx.databinding.BindingAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.boostcampwm2023.snappoint.databinding.ItemImageBlockBinding
 import com.boostcampwm2023.snappoint.databinding.ItemTextBlockBinding
-import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
+import com.boostcampwm2023.snappoint.presentation.model.PostBlockCreationState
 
 class CreatePostListAdapter(
     private val blockItemEvent: BlockItemEventListener
 ) : RecyclerView.Adapter<BlockItemViewHolder>() {
 
-    private var blocks: MutableList<PostBlockState> = mutableListOf()
+    private var blocks: MutableList<PostBlockCreationState> = mutableListOf()
 
     fun getCurrentBlocks() = blocks.toList()
 
-    fun updateBlocks(newBlocks: List<PostBlockState>) {
+    fun updateBlocks(newBlocks: List<PostBlockCreationState>) {
         blocks = newBlocks.toMutableList()
     }
 
@@ -44,9 +44,9 @@ class CreatePostListAdapter(
 
     override fun getItemViewType(position: Int): Int {
         return when (blocks[position]) {
-            is PostBlockState.TEXT -> PostBlockState.ViewType.TEXT.ordinal
-            is PostBlockState.IMAGE -> PostBlockState.ViewType.IMAGE.ordinal
-            is PostBlockState.VIDEO -> PostBlockState.ViewType.VIDEO.ordinal
+            is PostBlockCreationState.TEXT -> PostBlockCreationState.ViewType.TEXT.ordinal
+            is PostBlockCreationState.IMAGE -> PostBlockCreationState.ViewType.IMAGE.ordinal
+            is PostBlockCreationState.VIDEO -> PostBlockCreationState.ViewType.VIDEO.ordinal
         }
     }
 
@@ -72,14 +72,14 @@ class CreatePostListAdapter(
         }
 
         when (viewType) {
-            PostBlockState.ViewType.IMAGE.ordinal -> {
+            PostBlockCreationState.ViewType.IMAGE.ordinal -> {
                 return BlockItemViewHolder.ImageBlockViewHolder(
                     binding = ItemImageBlockBinding.inflate(inflater, parent, false),
                     blockItemEvent = itemEvent
                 )
             }
 
-            PostBlockState.ViewType.VIDEO.ordinal -> {
+            PostBlockCreationState.ViewType.VIDEO.ordinal -> {
                 TODO()
             }
         }
@@ -95,8 +95,8 @@ class CreatePostListAdapter(
 
     override fun onBindViewHolder(holder: BlockItemViewHolder, position: Int) {
         when (holder) {
-            is BlockItemViewHolder.TextBlockViewHolder -> holder.bind(blocks[position] as PostBlockState.TEXT, position)
-            is BlockItemViewHolder.ImageBlockViewHolder -> holder.bind(blocks[position] as PostBlockState.IMAGE, position)
+            is BlockItemViewHolder.TextBlockViewHolder -> holder.bind(blocks[position] as PostBlockCreationState.TEXT, position)
+            is BlockItemViewHolder.ImageBlockViewHolder -> holder.bind(blocks[position] as PostBlockCreationState.IMAGE, position)
         }
     }
 
@@ -113,7 +113,7 @@ class CreatePostListAdapter(
 
 @BindingAdapter("blocks", "blockItemEvent")
 fun RecyclerView.bindRecyclerViewAdapter(
-    blocks: List<PostBlockState>,
+    blocks: List<PostBlockCreationState>,
     blockItemEvent: BlockItemEventListener
 ) {
     if (adapter == null) adapter = CreatePostListAdapter(blockItemEvent)
@@ -140,14 +140,14 @@ fun RecyclerView.bindRecyclerViewAdapter(
                         notifyItemChanged(off)
                     }
                     when (postBlock) {
-                        is PostBlockState.IMAGE -> {
-                            if (postBlock.address != (blocks[index] as PostBlockState.IMAGE).address) {
+                        is PostBlockCreationState.IMAGE -> {
+                            if (postBlock.address != (blocks[index] as PostBlockCreationState.IMAGE).address) {
                                 notifyItemChanged(index)
                             }
                         }
 
-                        is PostBlockState.VIDEO -> {
-                            if (postBlock.address != (blocks[index] as PostBlockState.VIDEO).address) {
+                        is PostBlockCreationState.VIDEO -> {
+                            if (postBlock.address != (blocks[index] as PostBlockCreationState.VIDEO).address) {
                                 notifyItemChanged(index)
                             }
                         }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostUiState.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostUiState.kt
@@ -1,10 +1,10 @@
 package com.boostcampwm2023.snappoint.presentation.createpost
 
-import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
+import com.boostcampwm2023.snappoint.presentation.model.PostBlockCreationState
 
 data class CreatePostUiState(
     val title: String = "",
-    val postBlocks: List<PostBlockState> = mutableListOf(),
+    val postBlocks: List<PostBlockCreationState> = mutableListOf(),
     val isLoading: Boolean = false,
     val blockItemEvent: BlockItemEventListener,
 )

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostViewModel.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.boostcampwm2023.snappoint.R
 import com.boostcampwm2023.snappoint.data.repository.PostRepository
 import com.boostcampwm2023.snappoint.presentation.model.PositionState
-import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
+import com.boostcampwm2023.snappoint.presentation.model.PostBlockCreationState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -53,7 +53,7 @@ class CreatePostViewModel @Inject constructor(
     fun addTextBlock() {
         _uiState.update {
             it.copy(
-                postBlocks = it.postBlocks.plus(PostBlockState.TEXT())
+                postBlocks = it.postBlocks.plus(PostBlockCreationState.TEXT())
             )
         }
     }
@@ -61,7 +61,7 @@ class CreatePostViewModel @Inject constructor(
     fun addImageBlock(bitmap: Bitmap, position: PositionState) {
         _uiState.update {
             it.copy(
-                postBlocks = it.postBlocks + PostBlockState.IMAGE(bitmap = bitmap, position = position)
+                postBlocks = it.postBlocks + PostBlockCreationState.IMAGE(bitmap = bitmap, position = position)
             )
         }
     }
@@ -92,9 +92,9 @@ class CreatePostViewModel @Inject constructor(
                 postBlocks = it.postBlocks.mapIndexed { idx, postBlock ->
                     if(index == idx) {
                         when(postBlock){
-                            is PostBlockState.TEXT -> postBlock.copy(content = content)
-                            is PostBlockState.IMAGE -> postBlock.copy(description = content)
-                            is PostBlockState.VIDEO -> TODO()
+                            is PostBlockCreationState.TEXT -> postBlock.copy(content = content)
+                            is PostBlockCreationState.IMAGE -> postBlock.copy(description = content)
+                            is PostBlockCreationState.VIDEO -> TODO()
                         }
                     }else{
                         postBlock
@@ -110,15 +110,15 @@ class CreatePostViewModel @Inject constructor(
                 postBlocks = it.postBlocks.mapIndexed { index, postBlock ->
                     if (position == index) {
                         when (postBlock) {
-                            is PostBlockState.TEXT -> postBlock.copy(isEditMode = true)
-                            is PostBlockState.IMAGE -> postBlock.copy(isEditMode = true)
-                            is PostBlockState.VIDEO -> postBlock.copy(isEditMode = true)
+                            is PostBlockCreationState.TEXT -> postBlock.copy(isEditMode = true)
+                            is PostBlockCreationState.IMAGE -> postBlock.copy(isEditMode = true)
+                            is PostBlockCreationState.VIDEO -> postBlock.copy(isEditMode = true)
                         }
                     } else {
                         when (postBlock) {
-                            is PostBlockState.TEXT -> postBlock.copy(isEditMode = false)
-                            is PostBlockState.IMAGE -> postBlock.copy(isEditMode = false)
-                            is PostBlockState.VIDEO -> postBlock.copy(isEditMode = false)
+                            is PostBlockCreationState.TEXT -> postBlock.copy(isEditMode = false)
+                            is PostBlockCreationState.IMAGE -> postBlock.copy(isEditMode = false)
+                            is PostBlockCreationState.VIDEO -> postBlock.copy(isEditMode = false)
                         }
                     }
                 }
@@ -132,9 +132,9 @@ class CreatePostViewModel @Inject constructor(
                 postBlocks = it.postBlocks.mapIndexed { index, postBlock ->
                     if (position == index) {
                         when (postBlock) {
-                            is PostBlockState.TEXT -> postBlock.copy(isEditMode = false)
-                            is PostBlockState.IMAGE -> postBlock.copy(isEditMode = false)
-                            is PostBlockState.VIDEO -> postBlock.copy(isEditMode = false)
+                            is PostBlockCreationState.TEXT -> postBlock.copy(isEditMode = false)
+                            is PostBlockCreationState.IMAGE -> postBlock.copy(isEditMode = false)
+                            is PostBlockCreationState.VIDEO -> postBlock.copy(isEditMode = false)
                         }
                     } else {
                         postBlock
@@ -175,19 +175,19 @@ class CreatePostViewModel @Inject constructor(
     }
 
     private fun isValidTextBlock(): Boolean {
-        return _uiState.value.postBlocks.find { it is PostBlockState.TEXT && it.content.isEmpty() } == null
+        return _uiState.value.postBlocks.find { it is PostBlockCreationState.TEXT && it.content.isEmpty() } == null
     }
 
     private fun isValidMediaBlock(): Boolean {
-        return _uiState.value.postBlocks.find { (it is PostBlockState.TEXT).not() } != null
+        return _uiState.value.postBlocks.find { (it is PostBlockCreationState.TEXT).not() } != null
     }
 
     private fun isValidContents(): Boolean {
         _uiState.value.postBlocks.forEach {
             when(it){
-                is PostBlockState.TEXT -> {if(it.content.isEmpty()) return false}
-                is PostBlockState.IMAGE -> {if(it.content.isEmpty()) return false}
-                is PostBlockState.VIDEO -> {if(it.content.isEmpty()) return false}
+                is PostBlockCreationState.TEXT -> {if(it.content.isEmpty()) return false}
+                is PostBlockCreationState.IMAGE -> {if(it.content.isEmpty()) return false}
+                is PostBlockCreationState.VIDEO -> {if(it.content.isEmpty()) return false}
             }
         }
         return true
@@ -249,11 +249,11 @@ class CreatePostViewModel @Inject constructor(
     private fun findAddress(index: Int) {
 
         when(val target = _uiState.value.postBlocks[index]){
-            is PostBlockState.TEXT -> {return}
-            is PostBlockState.IMAGE -> {
+            is PostBlockCreationState.TEXT -> {return}
+            is PostBlockCreationState.IMAGE -> {
                 _event.tryEmit(CreatePostEvent.FindAddress(index, target.position))
             }
-            is PostBlockState.VIDEO -> {
+            is PostBlockCreationState.VIDEO -> {
                 _event.tryEmit(CreatePostEvent.FindAddress(index, target.position))
             }
         }
@@ -266,9 +266,9 @@ class CreatePostViewModel @Inject constructor(
                 postBlocks = it.postBlocks.mapIndexed { idx, postBlock ->
                     if(idx == index){
                         when(postBlock){
-                            is PostBlockState.IMAGE ->  PostBlockState.IMAGE(content = postBlock.content, position = position, address = address, bitmap = postBlock.bitmap)
-                            is PostBlockState.VIDEO -> PostBlockState.VIDEO(content = postBlock.content, position = position, address = address)
-                            is PostBlockState.TEXT -> postBlock
+                            is PostBlockCreationState.IMAGE ->  PostBlockCreationState.IMAGE(content = postBlock.content, position = position, address = address, bitmap = postBlock.bitmap)
+                            is PostBlockCreationState.VIDEO -> PostBlockCreationState.VIDEO(content = postBlock.content, position = position, address = address)
+                            is PostBlockCreationState.TEXT -> postBlock
                         }
                     }else{
                         postBlock

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/subscription/SubscriptionFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/subscription/SubscriptionFragment.kt
@@ -7,7 +7,9 @@ import com.boostcampwm2023.snappoint.R
 import com.boostcampwm2023.snappoint.databinding.FragmentSubscriptionBinding
 import com.boostcampwm2023.snappoint.presentation.base.BaseFragment
 import com.boostcampwm2023.snappoint.presentation.createpost.CreatePostActivity
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class SubscriptionFragment : BaseFragment<FragmentSubscriptionBinding>(R.layout.fragment_subscription) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/subscription/SubscriptionFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/subscription/SubscriptionFragment.kt
@@ -3,6 +3,7 @@ package com.boostcampwm2023.snappoint.presentation.main.subscription
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import androidx.fragment.app.viewModels
 import com.boostcampwm2023.snappoint.R
 import com.boostcampwm2023.snappoint.databinding.FragmentSubscriptionBinding
 import com.boostcampwm2023.snappoint.presentation.base.BaseFragment
@@ -11,6 +12,8 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class SubscriptionFragment : BaseFragment<FragmentSubscriptionBinding>(R.layout.fragment_subscription) {
+
+    private val viewModel: SubscriptionViewModel by viewModels()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -22,6 +25,9 @@ class SubscriptionFragment : BaseFragment<FragmentSubscriptionBinding>(R.layout.
         binding.btnCreatePost.setOnClickListener {
             val intent = Intent(requireContext(), CreatePostActivity::class.java)
             startActivity(intent)
+        }
+        binding.btnGetPostInRoom.setOnClickListener {
+            viewModel.getSavedPost()
         }
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/subscription/SubscriptionViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/subscription/SubscriptionViewModel.kt
@@ -1,0 +1,14 @@
+package com.boostcampwm2023.snappoint.presentation.main.subscription
+
+import androidx.lifecycle.ViewModel
+import com.boostcampwm2023.snappoint.data.repository.RoomRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class SubscriptionViewModel @Inject constructor(
+    private val roomRepository: RoomRepository
+) : ViewModel() {
+
+
+}

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/subscription/SubscriptionViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/subscription/SubscriptionViewModel.kt
@@ -1,8 +1,13 @@
 package com.boostcampwm2023.snappoint.presentation.main.subscription
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.boostcampwm2023.snappoint.data.repository.RoomRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
 @HiltViewModel
@@ -10,5 +15,12 @@ class SubscriptionViewModel @Inject constructor(
     private val roomRepository: RoomRepository
 ) : ViewModel() {
 
-
+    fun getSavedPost() {
+        roomRepository.getLocalPosts()
+            .onEach {
+                Log.d("LOG", it.toString())
+            }.catch {
+                Log.d("LOG", "Catch: ${it.message}}")
+            }.launchIn(viewModelScope)
+    }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/model/Post.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/model/Post.kt
@@ -2,7 +2,9 @@ package com.boostcampwm2023.snappoint.presentation.model
 
 import android.graphics.Bitmap
 import com.google.android.gms.maps.model.LatLng
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class PostSummaryState(
     val uuid: String = "",
     val title: String = "",
@@ -12,12 +14,18 @@ data class PostSummaryState(
     val postBlocks: List<PostBlockState> = emptyList()
 )
 
-sealed class PostBlockState(open val content: String, open val isEditMode: Boolean, open val uuid: String) {
+@Serializable
+sealed class PostBlockState {
+    abstract val content: String
+    abstract val isEditMode: Boolean
+    abstract val uuid: String
+    @Serializable
     data class TEXT(
         override val content: String = "",
         override val isEditMode: Boolean = false,
         override val uuid: String = "",
-    ) : PostBlockState(content, isEditMode, uuid)
+    ) : PostBlockState()
+    @Serializable
     data class IMAGE(
         override val content: String = "",
         override val isEditMode: Boolean = false,
@@ -25,8 +33,8 @@ sealed class PostBlockState(open val content: String, open val isEditMode: Boole
         val description: String = "",
         val position: PositionState = PositionState(0.0, 0.0),
         val address: String = "",
-        val bitmap: Bitmap? = null
-    ) : PostBlockState(content, isEditMode, uuid)
+    ) : PostBlockState()
+    @Serializable
     data class VIDEO(
         override val content: String = "",
         override val isEditMode: Boolean = false,
@@ -34,8 +42,8 @@ sealed class PostBlockState(open val content: String, open val isEditMode: Boole
         val description: String = "",
         val position: PositionState = PositionState(0.0, 0.0),
         val address: String = ""
-    ) : PostBlockState(content, isEditMode, uuid)
-
+    ) : PostBlockState()
+    @Serializable
     enum class ViewType {
         TEXT,
         IMAGE,
@@ -43,6 +51,7 @@ sealed class PostBlockState(open val content: String, open val isEditMode: Boole
     }
 }
 
+@Serializable
 data class PositionState(
     val latitude: Double,
     val longitude: Double

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/model/PostCreation.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/model/PostCreation.kt
@@ -1,0 +1,49 @@
+package com.boostcampwm2023.snappoint.presentation.model
+
+import android.graphics.Bitmap
+
+data class PostCreationState(
+    val uuid: String = "",
+    val title: String = "",
+    val author: String = "",
+    val timeStamp: String = "",
+    val summary: String = "",
+    val postBlocks: List<PostBlockCreationState> = emptyList()
+)
+
+sealed class PostBlockCreationState {
+    abstract val content: String
+    abstract val isEditMode: Boolean
+    abstract val uuid: String
+
+    data class TEXT(
+        override val content: String = "",
+        override val isEditMode: Boolean = false,
+        override val uuid: String = "",
+    ) : PostBlockCreationState()
+
+    data class IMAGE(
+        override val content: String = "",
+        override val isEditMode: Boolean = false,
+        override val uuid: String = "",
+        val description: String = "",
+        val position: PositionState = PositionState(0.0, 0.0),
+        val address: String = "",
+        val bitmap: Bitmap? = null
+    ) : PostBlockCreationState()
+
+    data class VIDEO(
+        override val content: String = "",
+        override val isEditMode: Boolean = false,
+        override val uuid: String = "",
+        val description: String = "",
+        val position: PositionState = PositionState(0.0, 0.0),
+        val address: String = ""
+    ) : PostBlockCreationState()
+
+    enum class ViewType {
+        TEXT,
+        IMAGE,
+        VIDEO,
+    }
+}

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/viewpost/post/PostEvent.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/viewpost/post/PostEvent.kt
@@ -2,4 +2,5 @@ package com.boostcampwm2023.snappoint.presentation.viewpost.post
 
 sealed class PostEvent {
     data object NavigatePrev: PostEvent()
+    data object SavePost: PostEvent()
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/viewpost/post/PostFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/viewpost/post/PostFragment.kt
@@ -45,17 +45,21 @@ class PostFragment : BaseFragment<FragmentPostBinding>(R.layout.fragment_post) {
                     }
 
                     PostEvent.SavePost -> {
-                        with(viewPostViewModel.post.value) {
-                            postViewModel.saveCurrentPost(
-                                title = title,
-                                author = author,
-                                timeStamp = timeStamp,
-                                blocks = postBlocks
-                            )
-                        }
+                        saveCurrentPost()
                     }
                 }
             }
+        }
+    }
+
+    private fun saveCurrentPost() {
+        with(viewPostViewModel.post.value) {
+            postViewModel.saveCurrentPost(
+                title = title,
+                author = author,
+                timeStamp = timeStamp,
+                blocks = postBlocks
+            )
         }
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/viewpost/post/PostFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/viewpost/post/PostFragment.kt
@@ -53,13 +53,6 @@ class PostFragment : BaseFragment<FragmentPostBinding>(R.layout.fragment_post) {
     }
 
     private fun saveCurrentPost() {
-        with(viewPostViewModel.post.value) {
-            postViewModel.saveCurrentPost(
-                title = title,
-                author = author,
-                timeStamp = timeStamp,
-                blocks = postBlocks
-            )
-        }
+        postViewModel.saveCurrentPost(viewPostViewModel.post.value)
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/viewpost/post/PostFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/viewpost/post/PostFragment.kt
@@ -43,6 +43,17 @@ class PostFragment : BaseFragment<FragmentPostBinding>(R.layout.fragment_post) {
                             viewPostViewModel.finishPostView()
                         }
                     }
+
+                    PostEvent.SavePost -> {
+                        with(viewPostViewModel.post.value) {
+                            postViewModel.saveCurrentPost(
+                                title = title,
+                                author = author,
+                                timeStamp = timeStamp,
+                                blocks = postBlocks
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/viewpost/post/PostViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/viewpost/post/PostViewModel.kt
@@ -1,12 +1,15 @@
 package com.boostcampwm2023.snappoint.presentation.viewpost.post
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.boostcampwm2023.snappoint.data.repository.RoomRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -22,5 +25,11 @@ class PostViewModel @Inject constructor(
 
     fun navigateToPrevious() {
         _event.tryEmit(PostEvent.NavigatePrev)
+    }
+
+    fun onLikeButtonClick() {
+        viewModelScope.launch(Dispatchers.IO){
+            //roomRepository.insertPosts(this)
+        }
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/viewpost/post/PostViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/viewpost/post/PostViewModel.kt
@@ -3,6 +3,7 @@ package com.boostcampwm2023.snappoint.presentation.viewpost.post
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.boostcampwm2023.snappoint.data.repository.RoomRepository
+import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BufferOverflow
@@ -28,8 +29,10 @@ class PostViewModel @Inject constructor(
     }
 
     fun onLikeButtonClick() {
-        viewModelScope.launch(Dispatchers.IO){
-            //roomRepository.insertPosts(this)
-        }
+        _event.tryEmit(PostEvent.SavePost)
+    }
+
+    fun saveCurrentPost(title: String, author: String, timeStamp: String, blocks: List<PostBlockState>) {
+
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/viewpost/post/PostViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/viewpost/post/PostViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.boostcampwm2023.snappoint.data.repository.RoomRepository
 import com.boostcampwm2023.snappoint.presentation.model.PostBlockState
+import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BufferOverflow
@@ -32,7 +33,9 @@ class PostViewModel @Inject constructor(
         _event.tryEmit(PostEvent.SavePost)
     }
 
-    fun saveCurrentPost(title: String, author: String, timeStamp: String, blocks: List<PostBlockState>) {
-
+    fun saveCurrentPost(post: PostSummaryState) {
+        viewModelScope.launch(Dispatchers.IO) {
+            roomRepository.insertPosts(post)
+        }
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/viewpost/post/PostViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/viewpost/post/PostViewModel.kt
@@ -1,6 +1,7 @@
 package com.boostcampwm2023.snappoint.presentation.viewpost.post
 
 import androidx.lifecycle.ViewModel
+import com.boostcampwm2023.snappoint.data.repository.RoomRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -9,7 +10,9 @@ import kotlinx.coroutines.flow.asSharedFlow
 import javax.inject.Inject
 
 @HiltViewModel
-class PostViewModel @Inject constructor() : ViewModel() {
+class PostViewModel @Inject constructor(
+    private val roomRepository: RoomRepository
+) : ViewModel() {
 
     private val _event: MutableSharedFlow<PostEvent> = MutableSharedFlow(
         extraBufferCapacity = 1,

--- a/android/app/src/main/res/layout/fragment_post.xml
+++ b/android/app/src/main/res/layout/fragment_post.xml
@@ -119,7 +119,7 @@
             android:layout_gravity="bottom" />
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/fab_save_current_post"
+            android:id="@+id/fab_like"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:srcCompat="@drawable/icon_popular_post"

--- a/android/app/src/main/res/layout/fragment_post.xml
+++ b/android/app/src/main/res/layout/fragment_post.xml
@@ -118,5 +118,13 @@
             android:layout_height="60dp"
             android:layout_gravity="bottom" />
 
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fab_save_current_post"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:srcCompat="@drawable/icon_popular_post"
+            app:layout_anchor="@id/bottomAppBar"
+            />
+
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </layout>

--- a/android/app/src/main/res/layout/fragment_post.xml
+++ b/android/app/src/main/res/layout/fragment_post.xml
@@ -113,7 +113,7 @@
         </androidx.core.widget.NestedScrollView>
 
         <com.google.android.material.bottomappbar.BottomAppBar
-            android:id="@+id/bottomAppBar"
+            android:id="@+id/bottom_app_bar"
             android:layout_width="match_parent"
             android:layout_height="60dp"
             android:layout_gravity="bottom" />
@@ -123,7 +123,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:srcCompat="@drawable/icon_popular_post"
-            app:layout_anchor="@id/bottomAppBar"
+            app:layout_anchor="@id/bottom_app_bar"
             />
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/android/app/src/main/res/layout/fragment_post.xml
+++ b/android/app/src/main/res/layout/fragment_post.xml
@@ -124,7 +124,7 @@
             android:layout_height="wrap_content"
             app:srcCompat="@drawable/icon_popular_post"
             app:layout_anchor="@id/bottom_app_bar"
-            />
+            android:onClick="@{()->vm.onLikeButtonClick()}" />
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </layout>

--- a/android/app/src/main/res/layout/fragment_subscription.xml
+++ b/android/app/src/main/res/layout/fragment_subscription.xml
@@ -23,6 +23,15 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"/>
 
+        <Button
+            android:id="@+id/btn_get_post_in_room"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="저장된 게시글 불러오기"
+            app:layout_constraintTop_toBottomOf="@+id/btn_create_post"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"/>
+
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#216): 게시글 로컬에 저장 - [F-08]: 게시글을 저장할 수 있다. -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
- [x] Room으로 게시글 저장

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- 게시글 작성 시 PostCreationState로 관리
- 게시글 열림 시 PostSummaryState로 관리
  - bitmap 삭제 및 직렬화
- Room 구현
  - Database, Entity, Dao, Repository

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
- 리스트나 클래스는 바로 저장하지 못 하기 때문에 `PostSummaryState`를 직렬화 해서 `Json`으로 저장했습니다.
- PostSummaryState를 바로 저장하면 DAO에서 presentation layer를 직접 참조하게 돼서 일단은 Entity를 남겨뒀습니다.
- 게시글이 수정된다면 저장된 게시글도 업데이트 해야할까요??
- 이전 게시글을 저장하고 나중에 수정된 게시글을 다시 저장한다면 어떻게 작동하는 것이 좋을까요?? 
  - 둘 다 저장하기 or 덮어쓰기


## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->
- Post 화면
![new-2023-12-05-17-01-00](https://github.com/boostcampwm2023/and01-SnapPoint/assets/76683420/71bb13f8-27f1-4849-b586-e6b339dbc69e)

- Log
![image](https://github.com/boostcampwm2023/and01-SnapPoint/assets/76683420/1cd8adf5-8c9e-477e-b9c9-29a437c696a0)
