### PR TITLE
Fix: 네비게이션 화면 전환 수정

### DIFF
--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/auth/signin/SignInFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/auth/signin/SignInFragment.kt
@@ -7,6 +7,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.NavController
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.navigateUp
@@ -22,6 +23,7 @@ class SignInFragment : BaseFragment<FragmentSigninBinding>(R.layout.fragment_sig
 
     private val activityViewModel: AuthViewModel by activityViewModels()
     private val viewModel: SignInViewModel by viewModels()
+    private val navController: NavController by lazy { findNavController() }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -60,12 +62,15 @@ class SignInFragment : BaseFragment<FragmentSigninBinding>(R.layout.fragment_sig
     }
 
     private fun navigateToMainActivity() {
-        findNavController().navigate(SignInFragmentDirections.actionLoginFragmentToMainActivity())
+        navController.navigate(SignInFragmentDirections.actionLoginFragmentToMainActivity())
         requireActivity().finish()
-
     }
 
     private fun navigateToSignup() {
-        findNavController().navigate(SignInFragmentDirections.actionLoginFragmentToSignupFragment())
+        navController.run {
+            if (currentDestination?.id != R.id.signUpFragment) {
+                navigate(R.id.action_loginFragment_to_signupFragment)
+            }
+        }
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/auth/signup/SignupFragment.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/auth/signup/SignupFragment.kt
@@ -53,6 +53,7 @@ class SignupFragment : BaseFragment<FragmentSignupBinding>(R.layout.fragment_sig
                         }
 
                         is SignupEvent.NavigateToSignIn -> {
+                            showToastMessage(R.string.signup_fragment_create_account_success)
                             navigateToSignIn()
                         }
                     }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/auth/signup/SignupViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/auth/signup/SignupViewModel.kt
@@ -128,7 +128,7 @@ class SignupViewModel @Inject constructor(
     }
 
     private fun getNicknameErrorCode(nickname: String): Int? {
-        return if (nickname.length > 1) null else R.string.signup_fragment_error_nickname
+        return if (nickname.length > 2) null else R.string.signup_fragment_error_nickname
     }
 
     fun onSignUpButtonClicked() {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -26,7 +26,7 @@
     <string name="btn_preview_text">미리보기</string>
     <string name="btn_view_post_text">게시글 보기</string>
     <string name="create_post_activity_post_creation_success">게시글 작성 성공했습니다 !</string>
-    <string name="signup_fragment_create_account_success">이메일 형식으로 입력해주세요.</string>
+    <string name="signup_fragment_create_account_success">계정을 생성했습니다.</string>
     <string name="signup_fragment_error_email_form">이메일 형식으로 입력해주세요.</string>
     <string name="signup_fragment_error_email_duplicate">이미 사용중인 이메일입니다.</string>
     <string name="signup_fragment_error_password_length">8~16자 영문, 숫자, 특수문자를 사용하세요.</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -31,7 +31,7 @@
     <string name="signup_fragment_error_email_duplicate">이미 사용중인 이메일입니다.</string>
     <string name="signup_fragment_error_password_length">8~16자 영문, 숫자, 특수문자를 사용하세요.</string>
     <string name="signup_fragment_error_password_confirm_mismatch">비밀번호가 일치하지 않습니다.</string>
-    <string name="signup_fragment_error_nickname">별명은 2글자 이상 입력해주세요.</string>
+    <string name="signup_fragment_error_nickname">별명은 3글자 이상 입력해주세요.</string>
     <string name="signup_fragment_fail_duplicate">이미 존재하는 이메일입니다.</string>
     <string name="signup_fragment_fail">회원가입에 실패했습니다.</string>
     <string name="login_activity_e_mail">E-MAIL</string>


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): 화면 UI 그리기 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
- [x] 회원가입을 두 번 시도하면 종료되는 현상 해결
- [x] 일부 문자열 수정 

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- 화면 전환 전에 현재 위치를 확인하는 방법으로 종료되는 현상을 해결했습니다.
```
if (currentDestination?.id != R.id.signUpFragment) {
    navigate(R.id.action_loginFragment_to_signupFragment)
}
```
- 회원가입 성공시 실패 문자열을 표시하는 것을 수정했습니다.
- 별명을 3글자 이상 입력 받도록 했습니다.

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->
- 회원가입 시도
[Screen_recording_20231205_231759.webm](https://github.com/boostcampwm2023/and01-SnapPoint/assets/76683420/64511150-579d-44bd-a2b1-8d1ba32a915b)


