### PR TITLE
Feature(#15, #36): 영상 블록을 포함한 게시글 생성

### DIFF
--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/SnapPointApi.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/SnapPointApi.kt
@@ -21,7 +21,6 @@ import okhttp3.RequestBody
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
-import retrofit2.http.Header
 import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.PUT
@@ -47,15 +46,15 @@ interface SnapPointApi {
         @Body createPostRequest: CreatePostRequest,
     ): CreatePostResponse
 
-    @POST("signin")
+    @POST("auth/sign-in")
     suspend fun postSignIn(
-        @Body loginRequest: SignInRequest
+        @Body signInRequest: SignInRequest
     ): SignInResponse
 
-    @GET("logout")
+    @GET("auth/sign-out")
     suspend fun getSignOut()
 
-    @POST("signup")
+    @POST("auth/sign-up")
     suspend fun postSignUp(
         @Body signupRequest: SignupRequest
     ): SignupResponse

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/SnapPointApi.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/SnapPointApi.kt
@@ -17,6 +17,7 @@ import com.boostcampwm2023.snappoint.data.remote.model.response.SignupResponse
 import com.boostcampwm2023.snappoint.data.remote.model.response.VideoEndResponse
 import com.boostcampwm2023.snappoint.data.remote.model.response.VideoUrlResponse
 import okhttp3.MultipartBody
+import okhttp3.RequestBody
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -96,11 +97,11 @@ interface SnapPointApi {
         @Body videoAbortRequest: VideoAbortRequest
     ): Unit
 
-    @Multipart
+
     @PUT
     suspend fun putVideo(
         @Url url: String,
-        @Part body: MultipartBody.Part,
+        @Body body: RequestBody,
     ): Response<Unit>
 
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/SnapPointApi.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/SnapPointApi.kt
@@ -3,13 +3,19 @@ package com.boostcampwm2023.snappoint.data.remote
 import com.boostcampwm2023.snappoint.data.remote.model.request.CreatePostRequest
 import com.boostcampwm2023.snappoint.data.remote.model.request.SignInRequest
 import com.boostcampwm2023.snappoint.data.remote.model.request.SignupRequest
+import com.boostcampwm2023.snappoint.data.remote.model.request.VideoAbortRequest
+import com.boostcampwm2023.snappoint.data.remote.model.request.VideoEndRequest
+import com.boostcampwm2023.snappoint.data.remote.model.request.VideoUrlRequest
 import com.boostcampwm2023.snappoint.data.remote.model.response.CreatePostResponse
 import com.boostcampwm2023.snappoint.data.remote.model.response.GetPostResponse
+import com.boostcampwm2023.snappoint.data.remote.model.response.VideoStartResponse
 import com.boostcampwm2023.snappoint.data.remote.model.response.ImageResponse
 import com.boostcampwm2023.snappoint.data.remote.model.response.ImageUriResponse
 import com.boostcampwm2023.snappoint.data.remote.model.response.PostImageResponse
 import com.boostcampwm2023.snappoint.data.remote.model.response.SignInResponse
 import com.boostcampwm2023.snappoint.data.remote.model.response.SignupResponse
+import com.boostcampwm2023.snappoint.data.remote.model.response.VideoEndResponse
+import com.boostcampwm2023.snappoint.data.remote.model.response.VideoUrlResponse
 import okhttp3.MultipartBody
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -65,4 +71,25 @@ interface SnapPointApi {
     suspend fun getPost(
         @Path("uuid") uuid: String
     ): GetPostResponse
+
+    @GET("files/video-start")
+    suspend fun getVideoStart(
+        @Query("contentType") contentType: String,
+    ): VideoStartResponse
+
+    @POST("files/video-url")
+    suspend fun postVideoUrl(
+        @Body videoUrlRequest: VideoUrlRequest,
+    ): VideoUrlResponse
+
+    @POST("files/video-end")
+    suspend fun postVideoEnd(
+        @Body videoEndRequest: VideoEndRequest,
+    ): VideoEndResponse
+
+    @POST("files/video-abort")
+    suspend fun postVideoAbort(
+        @Body videoAbortRequest: VideoAbortRequest
+    ): Unit
+
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/SnapPointApi.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/SnapPointApi.kt
@@ -17,13 +17,17 @@ import com.boostcampwm2023.snappoint.data.remote.model.response.SignupResponse
 import com.boostcampwm2023.snappoint.data.remote.model.response.VideoEndResponse
 import com.boostcampwm2023.snappoint.data.remote.model.response.VideoUrlResponse
 import okhttp3.MultipartBody
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.Multipart
 import retrofit2.http.POST
+import retrofit2.http.PUT
 import retrofit2.http.Part
 import retrofit2.http.Path
 import retrofit2.http.Query
+import retrofit2.http.Url
 
 interface SnapPointApi {
 
@@ -91,5 +95,12 @@ interface SnapPointApi {
     suspend fun postVideoAbort(
         @Body videoAbortRequest: VideoAbortRequest
     ): Unit
+
+    @Multipart
+    @PUT
+    suspend fun putVideo(
+        @Url url: String,
+        @Part body: MultipartBody.Part,
+    ): Response<Unit>
 
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/model/request/VideoAbortRequest.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/model/request/VideoAbortRequest.kt
@@ -1,0 +1,13 @@
+package com.boostcampwm2023.snappoint.data.remote.model.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+
+@Serializable
+data class VideoAbortRequest(
+    @SerialName("key")
+    val key: String,
+    @SerialName("uploadId")
+    val uploadId: String,
+)

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/model/request/VideoEndRequest.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/model/request/VideoEndRequest.kt
@@ -1,0 +1,16 @@
+package com.boostcampwm2023.snappoint.data.remote.model.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class VideoEndRequest(
+    @SerialName("key")
+    val key: String,
+    @SerialName("uploadId")
+    val uploadId: String,
+    @SerialName("mimeType")
+    val mimeType: String,
+    @SerialName("parts")
+    val parts: List<String>,
+)

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/model/request/VideoEndRequest.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/model/request/VideoEndRequest.kt
@@ -12,5 +12,13 @@ data class VideoEndRequest(
     @SerialName("mimeType")
     val mimeType: String,
     @SerialName("parts")
-    val parts: List<String>,
+    val parts: List<Part>,
+)
+
+@Serializable
+data class Part(
+    @SerialName("PartNumber")
+    val partNumber: Int,
+    @SerialName("ETag")
+    val eTag: String,
 )

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/model/request/VideoUrlRequest.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/model/request/VideoUrlRequest.kt
@@ -1,0 +1,15 @@
+package com.boostcampwm2023.snappoint.data.remote.model.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class VideoUrlRequest(
+    @SerialName("key")
+    val key: String,
+    @SerialName("uploadId")
+    val uploadId: String,
+    @SerialName("partNumber")
+    val partNumber: Int,
+)
+

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/model/response/VideoEndResponse.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/model/response/VideoEndResponse.kt
@@ -1,0 +1,10 @@
+package com.boostcampwm2023.snappoint.data.remote.model.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class VideoEndResponse(
+    @SerialName("presignedUrl")
+    val preSignedUrl:String,
+)

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/model/response/VideoEndResponse.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/model/response/VideoEndResponse.kt
@@ -5,6 +5,10 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class VideoEndResponse(
-    @SerialName("presignedUrl")
-    val preSignedUrl:String,
+    @SerialName("uuid")
+    val uuid:String,
+    @SerialName("url")
+    val url:String,
+    @SerialName("mimeType")
+    val mimeType:String,
 )

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/model/response/VideoStartResponse.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/model/response/VideoStartResponse.kt
@@ -1,0 +1,12 @@
+package com.boostcampwm2023.snappoint.data.remote.model.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class VideoStartResponse(
+    @SerialName("key")
+    val key: String,
+    @SerialName("uploadId")
+    val uploadId: String,
+)

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/model/response/VideoUrlResponse.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/model/response/VideoUrlResponse.kt
@@ -5,6 +5,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class VideoUrlResponse(
-    @SerialName("presignedUrl")
+    @SerialName("preSignedUrl")
     val preSignedUrl: String,
 )

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/model/response/VideoUrlResponse.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/remote/model/response/VideoUrlResponse.kt
@@ -1,0 +1,10 @@
+package com.boostcampwm2023.snappoint.data.remote.model.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class VideoUrlResponse(
+    @SerialName("presignedUrl")
+    val preSignedUrl: String,
+)

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/repository/PostRepositoryImpl.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/repository/PostRepositoryImpl.kt
@@ -1,10 +1,15 @@
 package com.boostcampwm2023.snappoint.data.repository
 
+import android.util.Log
+import androidx.core.net.toFile
 import com.boostcampwm2023.snappoint.data.mapper.asPostBlock
 import com.boostcampwm2023.snappoint.data.mapper.asPostSummaryState
 import com.boostcampwm2023.snappoint.data.remote.SnapPointApi
 import com.boostcampwm2023.snappoint.data.remote.model.File
 import com.boostcampwm2023.snappoint.data.remote.model.request.CreatePostRequest
+import com.boostcampwm2023.snappoint.data.remote.model.request.Part
+import com.boostcampwm2023.snappoint.data.remote.model.request.VideoEndRequest
+import com.boostcampwm2023.snappoint.data.remote.model.request.VideoUrlRequest
 import com.boostcampwm2023.snappoint.data.remote.model.response.CreatePostResponse
 import com.boostcampwm2023.snappoint.presentation.model.PostBlockCreationState
 import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
@@ -15,6 +20,7 @@ import kotlinx.coroutines.flow.map
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.toRequestBody
+import retrofit2.Retrofit
 import javax.inject.Inject
 
 class PostRepositoryImpl @Inject constructor(
@@ -57,20 +63,15 @@ class PostRepositoryImpl @Inject constructor(
                     postBlocks = postBlocks.map {
                         when (it) {
                             is PostBlockCreationState.IMAGE -> {
-                                val requestBody = it.bitmap?.toByteArray()?.toRequestBody("image/webp".toMediaType())!!
-                                val multipartBody = MultipartBody.Part.createFormData("file", "image", requestBody)
-                                val uploadResult = snapPointApi.postImage(multipartBody)
-                                // TODO - 하나의 이미지 블럭에 사진이 여러개 들어갈 때 대응
+                                val uuid = uploadImageAndGetUUid(it)
                                 it.asPostBlock().copy(
-                                    files = listOf(File(uploadResult.uuid))
+                                    files = listOf(File(uuid))
                                 )
                             }
                             is PostBlockCreationState.VIDEO -> {
-                                val requestBody = it.address?.toByteArray()?.toRequestBody("video/webp".toMediaType())!!
-                                val multipartBody = MultipartBody.Part.createFormData("file", "video", requestBody)
-                                val uploadResult = snapPointApi.postImage(multipartBody)
+                                val uuid = uploadVideoAndGetUUid(it)
                                 it.asPostBlock().copy(
-                                    files = listOf(File(uploadResult.uuid))
+                                    files = listOf(File(uuid))
                                 )
                             }
                             else -> it.asPostBlock()
@@ -80,6 +81,62 @@ class PostRepositoryImpl @Inject constructor(
             }.map{request ->
                 snapPointApi.createPost(request)
             }
+    }
+
+    private suspend fun uploadVideoAndGetUUid(videoBlock: PostBlockCreationState.VIDEO): String {
+
+        val videoStartResponse = snapPointApi.getVideoStart(contentType = videoBlock.mimeType)
+        val (key, uploadId) = videoStartResponse
+
+        val file = java.io.File("/storage/emulated/0/Android/data/com.boostcampwm2023.snappoint/cache/123.mp4")
+        //val file = java.io.File(videoBlock.resultPath)
+
+        val fileByteArray = file.readBytes()
+        Log.d("TAG", "fileByteArray.size : ${fileByteArray.size}")
+        val parts = mutableListOf<Part>()
+        val MB5 = 1024*1024*5
+
+        for(partNumber in 0 until fileByteArray.size step MB5){
+            val postVideoUrlResponse = snapPointApi.postVideoUrl(
+                videoUrlRequest = VideoUrlRequest(
+                    key = key,
+                    uploadId = uploadId,
+                    partNumber = parts.size + 1
+                )
+            )
+            val preSignedUrl = postVideoUrlResponse.preSignedUrl
+            Log.d("TAG", "preSignedUrl: $preSignedUrl")
+            val body = fileByteArray.toRequestBody(
+                contentType = videoBlock.mimeType.toMediaType(),
+                offset = partNumber,
+                byteCount = MB5
+            )
+            val multipartBody = MultipartBody.Part.create(body)
+            val response = snapPointApi.putVideo(
+                url = preSignedUrl,
+                body = multipartBody
+            )
+            val eTag = response.headers().get("ETag")?: ""
+            Log.d("TAG", "response.headers(): ${response.headers().joinToString(" ")}")
+            Log.d("TAG", "etag: $eTag")
+            parts.add(Part(parts.size + 1, eTag))
+        }
+        val res = snapPointApi.postVideoEnd(
+            VideoEndRequest(
+                key = key,
+                uploadId = uploadId,
+                mimeType = videoBlock.mimeType,
+                parts = parts
+            )
+        )
+        return res.uuid
+    }
+
+    private suspend fun uploadImageAndGetUUid(imageBlock: PostBlockCreationState.IMAGE): String {
+        val requestBody = imageBlock.bitmap?.toByteArray()?.toRequestBody("image/webp".toMediaType())!!
+        val multipartBody = MultipartBody.Part.createFormData("file", "image", requestBody)
+        val uploadResult = snapPointApi.postImage(multipartBody)
+        return uploadResult.uuid
     }
 
     override fun getAroundPost(leftBottom: String, rightTop: String): Flow<List<PostSummaryState>> {

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/di/RemoteModule.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/di/RemoteModule.kt
@@ -31,7 +31,7 @@ object RemoteModule {
     @Singleton
     fun provideSnapPointApi(client: OkHttpClient): SnapPointApi{
         return Retrofit.Builder()
-            .baseUrl("http://175.45.195.153:3000/")
+            .baseUrl("https://snap-point.tatine.kr/")
             .client(client)
             .addConverterFactory(Json.asConverterFactory("application/json".toMediaType()))
             .build()

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/auth/signin/SignInViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/auth/signin/SignInViewModel.kt
@@ -1,5 +1,6 @@
 package com.boostcampwm2023.snappoint.presentation.auth.signin
 
+import android.util.Log
 import android.util.Patterns
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -76,6 +77,7 @@ class SignInViewModel @Inject constructor(
                 _event.emit(SignInEvent.NavigateToMainActivity)
             }
             .catch {
+                Log.d("TAG", "onLoginButtonClick: ${it.message}")
                 _event.emit(SignInEvent.ShowMessage(R.string.login_activity_fail))
             }
             .onCompletion {

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/BlockItemViewHolder.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/BlockItemViewHolder.kt
@@ -135,12 +135,16 @@ sealed class BlockItemViewHolder(
                 editMode = block.isEditMode
 
             }
-           /* val mediaItem = MediaItem.fromUri(block.uri)
-            val transformer = Transformer.Builder()
+
+            val mediaItem = MediaItem.fromUri(block.uri)
+
             binding.pv.player = ExoPlayer.Builder(itemView.context).build().also {
 
                 it.setMediaItem(mediaItem)
-            }*/
+                it.prepare()
+
+            }
+
             textWatcher.updatePosition(index)
         }
 

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostActivity.kt
@@ -8,7 +8,6 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.MediaStore
-import android.util.Log
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.core.content.ContextCompat
@@ -20,6 +19,7 @@ import com.boostcampwm2023.snappoint.databinding.ActivityCreatePostBinding
 import com.boostcampwm2023.snappoint.presentation.base.BaseActivity
 import com.boostcampwm2023.snappoint.presentation.markerpointselector.MarkerPointSelectorActivity
 import com.boostcampwm2023.snappoint.presentation.model.PositionState
+import com.boostcampwm2023.snappoint.presentation.model.PostBlockCreationState
 import com.boostcampwm2023.snappoint.presentation.util.MetadataUtil
 import com.boostcampwm2023.snappoint.presentation.util.getBitmapFromUri
 import com.boostcampwm2023.snappoint.presentation.util.resizeBitmap
@@ -70,22 +70,18 @@ class CreatePostActivity : BaseActivity<ActivityCreatePostBinding>(R.layout.acti
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.resultCode == RESULT_OK) {
                 val videoUri = result.data?.data ?: return@registerForActivityResult
-                Log.d("TAG", "videoUri: $videoUri")
                 val mediaMetadataRetriever = MediaMetadataRetriever().apply {
                     setDataSource(this@CreatePostActivity, videoUri)
                 }
                 val mimeType = mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_MIMETYPE)!!
-
                val inputStream = this.contentResolver.openInputStream(videoUri)
                     ?: return@registerForActivityResult
-                val a = this
                 val position = MetadataUtil.extractLocationFromInputStream(inputStream)
                     .getOrDefault(PositionState(0.0, 0.0))
 
-                //버전 11부터 파일을 가져와서 조작, 수정하는게 막힘
                 viewModel.addVideoBlock(videoUri, position, mimeType)
 
-                //startMapActivityAndFindAddress(viewModel.uiState.value.postBlocks.lastIndex, position)
+                //버전 11부터 파일을 가져와서 조작, 수정하는게 막힘
                 startVideoEditActivity(viewModel.uiState.value.postBlocks.lastIndex, videoUri)
             }
         }
@@ -112,18 +108,11 @@ class CreatePostActivity : BaseActivity<ActivityCreatePostBinding>(R.layout.acti
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.resultCode == RESULT_OK) {
                 result.data?.let{
-                    Log.d("TAG", "videoEditLauncher: ${it.getStringExtra("path")}")
                     val path = it.getStringExtra("path") ?: ""
                     viewModel.updateVideoPath(path)
-                    /*val outputUri = it.getStringExtra("output") ?: return@registerForActivityResult
-                    val file = this.contentResolver.openInputStream(outputUri.toUri())
-                    viewModel.setVideo(
-                        index = it.getIntExtra("index", 0),
-                        edittedVideo = it.getBy
-                    )*/
                 }
             }
-
+            startMapActivityAndFindAddress(viewModel.uiState.value.postBlocks.lastIndex, (viewModel.uiState.value.postBlocks.last() as PostBlockCreationState.VIDEO).position)
         }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostActivity.kt
@@ -81,7 +81,6 @@ class CreatePostActivity : BaseActivity<ActivityCreatePostBinding>(R.layout.acti
 
                 viewModel.addVideoBlock(videoUri, position, mimeType)
 
-                //버전 11부터 파일을 가져와서 조작, 수정하는게 막힘
                 startVideoEditActivity(viewModel.uiState.value.postBlocks.lastIndex, videoUri)
             }
         }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostViewModel.kt
@@ -54,7 +54,7 @@ class CreatePostViewModel @Inject constructor(
     fun addTextBlock() {
         _uiState.update {
             it.copy(
-                postBlocks = it.postBlocks.plus(PostBlockCreationState.TEXT())
+                postBlocks = it.postBlocks + PostBlockCreationState.TEXT()
             )
         }
     }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostViewModel.kt
@@ -67,10 +67,10 @@ class CreatePostViewModel @Inject constructor(
         }
     }
 
-    fun addVideoBlock(videoUri: Uri, position: PositionState) {
+    fun addVideoBlock(videoUri: Uri, position: PositionState, mimeType: String) {
         _uiState.update {
             it.copy(
-                postBlocks = it.postBlocks + PostBlockCreationState.VIDEO(uri = videoUri, position = position)
+                postBlocks = it.postBlocks + PostBlockCreationState.VIDEO(uri = videoUri, position = position, mimeType = mimeType)
             )
         }
     }
@@ -285,5 +285,23 @@ class CreatePostViewModel @Inject constructor(
                 }
             )
         }
+    }
+
+    fun updateVideoPath(path: String) {
+        val lastIndex = _uiState.value.postBlocks.lastIndex
+        _uiState.update {
+            it.copy(
+                postBlocks = it.postBlocks.mapIndexed { index, block ->
+                    if(index == lastIndex){
+                        (block as PostBlockCreationState.VIDEO).copy(
+                            resultPath = path
+                        )
+                    }else{
+                        block
+                    }
+                }
+            )
+        }
+
     }
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostViewModel.kt
@@ -275,8 +275,18 @@ class CreatePostViewModel @Inject constructor(
                 postBlocks = it.postBlocks.mapIndexed { idx, postBlock ->
                     if(idx == index){
                         when(postBlock){
-                            is PostBlockCreationState.IMAGE ->  PostBlockCreationState.IMAGE(content = postBlock.content, position = position, address = address, bitmap = postBlock.bitmap)
-                            is PostBlockCreationState.VIDEO -> PostBlockCreationState.VIDEO(content = postBlock.content, position = position, address = address, uri = postBlock.uri)
+                            is PostBlockCreationState.IMAGE -> {
+                                postBlock.copy(
+                                    position = position,
+                                    address = address,
+                                )
+                            }
+                            is PostBlockCreationState.VIDEO -> {
+                                postBlock.copy(
+                                    position = position,
+                                    address = address,
+                                )
+                            }
                             is PostBlockCreationState.TEXT -> postBlock
                         }
                     }else{

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/MainViewModel.kt
@@ -59,7 +59,11 @@ class MainViewModel @Inject constructor(
     fun loadPosts(leftBottom: String, rightTop: String) {
         postRepository.getAroundPost(leftBottom, rightTop)
             .onStart { startLoading() }
-            .catch { _event.tryEmit(MainActivityEvent.GetAroundPostFailed) }
+            .catch {
+                Log.d("TAG", "loadPosts: $it")
+                _event.tryEmit(MainActivityEvent.GetAroundPostFailed)
+
+            }
             .onCompletion { finishLoading() }
             .onEach { response ->
                 _postState.value = response

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/model/PostCreation.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/model/PostCreation.kt
@@ -40,7 +40,9 @@ sealed class PostBlockCreationState {
         val description: String = "",
         val position: PositionState = PositionState(0.0, 0.0),
         val address: String = "",
+        val mimeType: String = "",
         val uri:Uri,
+        val resultPath: String = "",
     ) : PostBlockCreationState()
 
     enum class ViewType {

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/splash/SplashActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/splash/SplashActivity.kt
@@ -34,12 +34,10 @@ class SplashActivity : BaseActivity<ActivitySplashBinding>(R.layout.activity_spl
                 viewModel.event.collect { event ->
                     when(event) {
                         is SplashEvent.Success -> {
-                            showToastMessage(R.string.sign_in_fragment_auto_login_success)
                             navigateToMainMap()
                         }
 
                         is SplashEvent.Fail -> {
-                            showToastMessage(R.string.sign_in_fragment_auto_login_fail)
                             navigateToSignIn()
                         }
                     }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/util/Constants.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/util/Constants.kt
@@ -10,4 +10,5 @@ object Constants {
     const val IS_LOCAL_POST_BUNDLE_KEY: String = "isLocalPost"
     const val CLUSTER_TEXT_SIZE = 16
     const val MIN_CLUSTER_SIZE = 2
+    const val BYTE_OF_VIDEO_PART_SIZE = 1024 * 1024 * 5
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/videoedit/VideoEditActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/videoedit/VideoEditActivity.kt
@@ -58,11 +58,14 @@ class VideoEditActivity : BaseActivity<ActivityVideoEditBinding>(R.layout.activi
             setDataSource(this@VideoEditActivity, viewModel.uri.value.toUri())
         }
         mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_COMPOSER)
+
         val videoLengthInMs = mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)!!.toLong() * 1000
     }
 
     private fun initTransFormer() {
+
         trans = Transformer.Builder(this@VideoEditActivity).setVideoMimeType(MimeTypes.VIDEO_H265).setAudioMimeType(MimeTypes.AUDIO_AAC).build()
+
         trans.addListener(object : Listener{
             override fun onCompleted(composition: Composition, exportResult: ExportResult) {
                 super.onCompleted(composition, exportResult)

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/videoedit/VideoEditActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/videoedit/VideoEditActivity.kt
@@ -1,20 +1,14 @@
 package com.boostcampwm2023.snappoint.presentation.videoedit
 
-import android.graphics.Rect
 import android.media.MediaMetadataRetriever
-import android.net.Uri
 import android.os.Bundle
-import android.os.PersistableBundle
 import android.util.Log
 import androidx.activity.viewModels
-import androidx.annotation.OptIn
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.ReportFragment.Companion.reportFragment
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.media3.common.MediaItem
-import androidx.media3.common.MediaMetadata
 import androidx.media3.common.MimeTypes
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
@@ -27,77 +21,74 @@ import com.boostcampwm2023.snappoint.R
 import com.boostcampwm2023.snappoint.databinding.ActivityVideoEditBinding
 import com.boostcampwm2023.snappoint.presentation.base.BaseActivity
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
-import okhttp3.MediaType
 import java.io.File
 
-@AndroidEntryPoint
+@UnstableApi @AndroidEntryPoint
 class VideoEditActivity : BaseActivity<ActivityVideoEditBinding>(R.layout.activity_video_edit) {
 
     private val viewModel: VideoEditViewModel by viewModels()
 
-    private var index = 0
+    private var postIndex = 0
 
-    @OptIn(UnstableApi::class) override fun onCreate(savedInstanceState: Bundle?) {
+    private lateinit var file: File
+    private lateinit var trans: Transformer
+    private lateinit var mediaItem: MediaItem
+
+     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        getIntentExtra()
+         getIntentExtra()
 
-        initBinding()
+         initMediaItem()
 
-        collectViewModelData()
+         createExternalCacheFile()
+
+         initBinding()
+
+         collectViewModelData()
+
+        initTransFormer()
 
 
-        val mediaItem = MediaItem.fromUri(viewModel.uri.value.toUri())
+    }
+
+    private fun initMediaItem() {
+        mediaItem = MediaItem.fromUri(viewModel.uri.value.toUri())
         val mediaMetadataRetriever = MediaMetadataRetriever().apply {
             setDataSource(this@VideoEditActivity, viewModel.uri.value.toUri())
         }
-        val trans = Transformer.Builder(this).setVideoMimeType(MimeTypes.VIDEO_H265).setAudioMimeType(MimeTypes.AUDIO_AAC).build()
-
-
-
         mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_COMPOSER)
         val videoLengthInMs = mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)!!.toLong() * 1000
-        binding.pv.player = ExoPlayer.Builder(this).build().also {
-            it.setMediaItem(mediaItem)
-            it.prepare()
-        }
-
-        binding.pv.useController = false
-
-        binding.btnCancel.setOnClickListener {
-            binding.pv.player?.play()
-        }
-        binding.btnConfirm.setOnClickListener {
-            //binding.pv.player?.seekTo(0)
-            val file = createExternalCacheFile("asdf.mp4")
-            trans.addListener(object : Listener{
-
-                override fun onCompleted(composition: Composition, exportResult: ExportResult) {
-                    super.onCompleted(composition, exportResult)
-                    intent.putExtra("path", file.path)
-                    setResult(RESULT_OK, intent)
-                    finish()
-                }
-
-                override fun onError(
-                    composition: Composition,
-                    exportResult: ExportResult,
-                    exportException: ExportException
-                ) {
-                    super.onError(composition, exportResult, exportException)
-                    Log.d("TAG", "onError: ${exportResult}")
-                    Log.d("TAG", "onError: ${exportException}")
-                }
-            })
-            trans.start(mediaItem, file.path)
-
-        }
-
     }
-    private fun createExternalCacheFile(fileName: String): File {
-        val  file = File(externalCacheDir, fileName);
+
+    private fun initTransFormer() {
+        trans = Transformer.Builder(this@VideoEditActivity).setVideoMimeType(MimeTypes.VIDEO_H265).setAudioMimeType(MimeTypes.AUDIO_AAC).build()
+        trans.addListener(object : Listener{
+            override fun onCompleted(composition: Composition, exportResult: ExportResult) {
+                super.onCompleted(composition, exportResult)
+                viewModel.finishLoading()
+                intent.putExtra("path", file.path)
+                setResult(RESULT_OK, intent)
+                finish()
+
+            }
+            override fun onError(
+                composition: Composition,
+                exportResult: ExportResult,
+                exportException: ExportException
+            ) {
+                super.onError(composition, exportResult, exportException)
+                viewModel.finishLoading()
+                showToastMessage(exportException.message?:"error")
+            }
+        })
+    }
+
+    private fun createExternalCacheFile() {
+
+        file = File(externalCacheDir, "video_edited.mp4")
+
         try{
             if (file.exists() && !file.delete()) {
                 throw IllegalStateException("Could not delete the previous export output file")
@@ -108,7 +99,6 @@ class VideoEditActivity : BaseActivity<ActivityVideoEditBinding>(R.layout.activi
         } catch (e:Exception){
             Log.d("TAG", "createExternalCacheFile: ${e.message}")
         }
-        return file
 
     }
 
@@ -138,13 +128,27 @@ class VideoEditActivity : BaseActivity<ActivityVideoEditBinding>(R.layout.activi
     private fun initBinding() {
         with(binding){
             vm = viewModel
+            pv.player = ExoPlayer.Builder(this@VideoEditActivity).build().also {
+                it.setMediaItem(mediaItem)
+                it.prepare()
+            }
+
+            pv.useController = false
+
+            btnCancel.setOnClickListener {
+                finish()
+            }
+            btnConfirm.setOnClickListener {
+                viewModel.startLoading()
+                trans.start(mediaItem, file.path)
+            }
         }
     }
 
     private fun getIntentExtra() {
         val uri = intent.getStringExtra("uri")?:""
         viewModel.setUri(uri)
-        index = intent.getIntExtra("index",0) ?: 0
+        postIndex = intent.getIntExtra("index",0) ?: 0
     }
 
 }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/videoedit/VideoEditActivity.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/videoedit/VideoEditActivity.kt
@@ -48,8 +48,7 @@ class VideoEditActivity : BaseActivity<ActivityVideoEditBinding>(R.layout.activi
 
          collectViewModelData()
 
-        initTransFormer()
-
+         initTransFormer()
 
     }
 

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/videoedit/VideoEditViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/videoedit/VideoEditViewModel.kt
@@ -21,6 +21,9 @@ class VideoEditViewModel @Inject constructor(
     private val _rightThumbState: MutableStateFlow<Long> = MutableStateFlow(0L)
     val rightThumbState: StateFlow<Long> = _rightThumbState.asStateFlow()
 
+    private val _isLoading: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
     fun onLeftThumbMoved(position: Long){
         _leftThumbState.update { position }
 
@@ -32,6 +35,17 @@ class VideoEditViewModel @Inject constructor(
     fun setUri(uri: String) {
         _uri.update {
             uri
+        }
+    }
+
+    fun startLoading(){
+        _isLoading.update {
+            true
+        }
+    }
+    fun finishLoading(){
+        _isLoading.update {
+            false
         }
     }
 }

--- a/android/app/src/main/res/layout/activity_video_edit.xml
+++ b/android/app/src/main/res/layout/activity_video_edit.xml
@@ -7,6 +7,7 @@
         <variable
             name="vm"
             type="com.boostcampwm2023.snappoint.presentation.videoedit.VideoEditViewModel" />
+        <import type="android.view.View" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -49,6 +50,16 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintBottom_toBottomOf="parent" />
+
+        <ProgressBar
+            android:id="@+id/pb"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:visibility="@{vm.isLoading ? View.VISIBLE : View.GONE}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/layout/item_video_block.xml
+++ b/android/app/src/main/res/layout/item_video_block.xml
@@ -114,6 +114,7 @@
             android:id="@+id/pv"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:minHeight="200dp"
             android:layout_marginTop="8dp"
             android:layout_marginHorizontal="1dp"
             app:layout_constraintTop_toBottomOf="@id/btn_delete_block"/>


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): 화면 UI 그리기 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->

- [x] 영상 업로드 api 추가
- [x] 영상 인코딩 및 절대경로 추출
- [x] 영상 파싱 후 서버 업로드
- [x] 이미지 블록 위치 정보 추가

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->

pre-signed api를 이용해 미디어 서버에 직접 업로드 할 수 있도록 구현했습니다.
안드로이드 버전 11부터는 개발자가 파일에 접근에 수정 및 조작이 불가능했습니다.
갤러리에서 가져온 요소의 절대 경로를 코드 상으로 얻을 수 없었기 때문에, 파일을 먼저 인코딩한 후 캐시 디렉토리에 저장하고, 해당 경로를 바탕으로 업로드 할 수 있도록 구현했습니다.

인코딩을 진행한 파일이 6MB에서 200KB로 줄었습니다.
화질과 용량의 관계를 파악하는 과정이 필요할 것 같습니다.

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->