### PR TITLE
[FIX] change `android cd` trigger branch (main)

### DIFF
--- a/.github/workflows/android-firebase-app-distribution.yml
+++ b/.github/workflows/android-firebase-app-distribution.yml
@@ -2,7 +2,7 @@ name: Android Build & upload to Firebase App Distribution
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: [ "main" ]
 
 defaults:
   run:


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): 화면 UI 그리기 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
gitgub actions로 설정한 android cd 브랜치의 트리거 기준을 main브랜치로 merge 했을 때로 변경했습니다.
