### PR TITLE
Feature: 기능 추가에 따른 개선

### DIFF
--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/mapper/PostMapper.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/mapper/PostMapper.kt
@@ -93,7 +93,7 @@ fun GetPostResponse.asPostSummaryState(): PostSummaryState {
     return PostSummaryState(
         uuid = this.postUuid,
         title = this.title,
-        author = "",
+        author = this.nickname,
         timeStamp = this.createdAt,
         summary = this.summary,
         email = email,
@@ -112,7 +112,7 @@ fun DeletePostResponse.asPostSummaryState(): PostSummaryState {
     return PostSummaryState(
         uuid = this.postUuid,
         title = this.title,
-        author = "",
+        author = this.nickname,
         timeStamp = this.createdAt,
         summary = this.summary,
         email = email,

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/SnapPointClusterRenderer.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/SnapPointClusterRenderer.kt
@@ -1,7 +1,6 @@
 package com.boostcampwm2023.snappoint.presentation.main
 
 import android.content.Context
-import android.util.Log
 import com.boostcampwm2023.snappoint.presentation.util.Constants.MIN_CLUSTER_SIZE
 import com.boostcampwm2023.snappoint.presentation.util.drawNumberOnSnapPoint
 import com.boostcampwm2023.snappoint.presentation.util.getSnapPointBitmap

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/clusterpreview/ClusterItemViewHolder.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/main/clusterpreview/ClusterItemViewHolder.kt
@@ -13,8 +13,20 @@ class ClusterItemViewHolder(
 
     fun bind(item: PostBlockState, index: Int) {
         with(binding) {
-            ivImage.load(item.content) {
-                memoryCachePolicy(CachePolicy.ENABLED)
+            when (item) {
+                is PostBlockState.IMAGE -> {
+                    ivImage.load(item.url480P) {
+                        memoryCachePolicy(CachePolicy.ENABLED)
+                    }
+                }
+
+                is PostBlockState.VIDEO -> {
+                    ivImage.load(item.thumbnail480P) {
+                        memoryCachePolicy(CachePolicy.ENABLED)
+                    }
+                }
+
+                else -> {}
             }
             root.setOnClickListener {
                 onItemClicked(index)

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/search/SearchResultViewHolder.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/search/SearchResultViewHolder.kt
@@ -3,7 +3,7 @@ package com.boostcampwm2023.snappoint.presentation.search
 import androidx.recyclerview.widget.RecyclerView
 import com.boostcampwm2023.snappoint.databinding.ItemSearchAutoCompleteBinding
 
-class AutoCompletionViewHolder(
+class SearchResultViewHolder(
     private val binding: ItemSearchAutoCompleteBinding,
     private val onAutoCompleteItemClicked: (Int) -> Unit,
 ) : RecyclerView.ViewHolder(binding.root) {

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/search/SearchViewListAdapter.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/search/SearchViewListAdapter.kt
@@ -10,16 +10,16 @@ import com.boostcampwm2023.snappoint.databinding.ItemSearchAutoCompleteBinding
 
 class AutoCompletionListAdapter(
     private val onAutoCompleteItemClicked: (Int) -> Unit
-) : ListAdapter<String, AutoCompletionViewHolder>(diffUtil) {
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AutoCompletionViewHolder {
+) : ListAdapter<String, SearchResultViewHolder>(diffUtil) {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SearchResultViewHolder {
         val inflater = LayoutInflater.from(parent.context)
-        return AutoCompletionViewHolder(
+        return SearchResultViewHolder(
             binding = ItemSearchAutoCompleteBinding.inflate(inflater, parent, false),
             onAutoCompleteItemClicked = onAutoCompleteItemClicked
         )
     }
 
-    override fun onBindViewHolder(holder: AutoCompletionViewHolder, position: Int) {
+    override fun onBindViewHolder(holder: SearchResultViewHolder, position: Int) {
         holder.bind(getItem(position), position)
     }
 

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/viewpost/ViewPostViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/viewpost/ViewPostViewModel.kt
@@ -7,7 +7,6 @@ import com.boostcampwm2023.snappoint.data.repository.PostRepository
 import com.boostcampwm2023.snappoint.data.repository.RoomRepository
 import com.boostcampwm2023.snappoint.data.repository.UserInfoRepository
 import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
-import com.boostcampwm2023.snappoint.presentation.viewpost.post.PostEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -20,11 +19,9 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.flow.update
 import javax.inject.Inject
-import kotlin.math.log
 
 @HiltViewModel
 class ViewPostViewModel @Inject constructor(


### PR DESCRIPTION
## 작업 개요
- [x] 게시글을 받아오는 API의 response에 닉네임이 추가되어, 게시글에 닉네임도 표시되도록 수정
- [x] 등록된 스냅 포인트(클러스터 클릭했을 때 화면)에서 영상의 썸네일도 보여지도록 수정

## 작업 사항
- API가 닉네임과 이메일도 보내주도록 수정되었는데, 그에 따라 게시글에 작성자의 닉네임도 표시되도록 수정
- `ClusterItemViewHolder`에서 item의 타입에 따라 480p의 이미지 혹은 썸네일을 bind 하도록 수정
