### PR TITLE
Fix: 영상 업로드 관련 

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         applicationId = "com.boostcampwm2023.snappoint"
         minSdk = 26
         targetSdk = 34
-        versionCode = 2
-        versionName = "0.2.0"
+        versionCode = 3
+        versionName = "0.3.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/data/repository/PostRepositoryImpl.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/data/repository/PostRepositoryImpl.kt
@@ -15,30 +15,36 @@ import com.boostcampwm2023.snappoint.presentation.model.PostBlockCreationState
 import com.boostcampwm2023.snappoint.presentation.model.PostSummaryState
 import com.boostcampwm2023.snappoint.presentation.util.Constants.BYTE_OF_VIDEO_PART_SIZE
 import com.boostcampwm2023.snappoint.presentation.util.toByteArray
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.internal.wait
 import javax.inject.Inject
 import kotlin.math.min
 
 class PostRepositoryImpl @Inject constructor(
     private val snapPointApi: SnapPointApi,
-): PostRepository {
+) : PostRepository {
     override fun getImage(uri: String): Flow<ByteArray> {
 
         return flowOf(true)
-            .map{
-            byteArrayOf()
-        }
+            .map {
+                byteArrayOf()
+            }
     }
 
     override fun getImageUri(image: ByteArray): Flow<Unit> {
 
         return flowOf(true)
-            .map{
+            .map {
 
             }
     }
@@ -46,7 +52,7 @@ class PostRepositoryImpl @Inject constructor(
     override fun getVideo(uri: String): Flow<ByteArray> {
 
         return flowOf(true)
-            .map{
+            .map {
                 byteArrayOf()
             }
     }
@@ -54,12 +60,15 @@ class PostRepositoryImpl @Inject constructor(
     override fun getVideoUri(video: ByteArray): Flow<Unit> {
 
         return flowOf(true)
-            .map{
+            .map {
 
             }
     }
 
-    override fun postCreatePost(title: String, postBlocks: List<PostBlockCreationState>): Flow<CreatePostResponse> {
+    override fun postCreatePost(
+        title: String,
+        postBlocks: List<PostBlockCreationState>
+    ): Flow<CreatePostResponse> {
 
         return flowOf(true)
             .map {
@@ -69,7 +78,11 @@ class PostRepositoryImpl @Inject constructor(
             }
     }
 
-    override fun putModifiedPost(uuid: String, title: String, postBlocks: List<PostBlockCreationState>): Flow<CreatePostResponse> {
+    override fun putModifiedPost(
+        uuid: String,
+        title: String,
+        postBlocks: List<PostBlockCreationState>
+    ): Flow<CreatePostResponse> {
 
         return flowOf(true)
             .map {
@@ -79,29 +92,34 @@ class PostRepositoryImpl @Inject constructor(
             }
     }
 
-    private suspend fun buildCreatePostRequest(title: String, postBlockStates: List<PostBlockCreationState>): CreatePostRequest {
+    private suspend fun buildCreatePostRequest(
+        title: String,
+        postBlockStates: List<PostBlockCreationState>
+    ): CreatePostRequest {
 
         val postBlocks: List<PostBlock> = postBlockStates.map { block ->
             when (block) {
                 is PostBlockCreationState.IMAGE -> {
-                    val fileUuid = if (block.uuid.isBlank()) uploadImageAndGetUUid(block) else block.fileUuid
+                    val fileUuid =
+                        if (block.uuid.isBlank()) uploadImageAndGetUUid(block) else block.fileUuid
                     block.asPostBlock().copy(
                         files = listOf(File(fileUuid))
                     )
                 }
+
                 is PostBlockCreationState.VIDEO -> {
                     val fileUuid = if (block.uuid.isBlank()) {
                         uploadVideoAndGetUUid(block)
                     } else {
                         block.fileUuid
                     }
-                    val thumbnailUuid = if(block.thumbnailUuid.isBlank()){
+                    val thumbnailUuid = if (block.thumbnailUuid.isBlank()) {
                         uploadImageAndGetUUid(
                             PostBlockCreationState.IMAGE(
                                 bitmap = block.thumbnail
                             )
                         )
-                    }else{
+                    } else {
                         block.thumbnailUuid
                     }
                     block.asPostBlock().copy(
@@ -126,28 +144,37 @@ class PostRepositoryImpl @Inject constructor(
         val fileByteArray = file.readBytes()
 
         val byteOfFileSize = fileByteArray.size
+        val partNum = byteOfFileSize / BYTE_OF_VIDEO_PART_SIZE + 1
         val parts = mutableListOf<Part>()
+        repeat(partNum) { part ->
 
-        for(partNumber in 0 until fileByteArray.size step BYTE_OF_VIDEO_PART_SIZE){
-            val postVideoUrlResponse = snapPointApi.postVideoUrl(
-                videoUrlRequest = VideoUrlRequest(
-                    key = key,
-                    uploadId = uploadId,
-                    partNumber = parts.size + 1
+            val partNumber = part * BYTE_OF_VIDEO_PART_SIZE
+
+            CoroutineScope(Dispatchers.IO).launch {
+                val postVideoUrlResponse = snapPointApi.postVideoUrl(
+                    videoUrlRequest = VideoUrlRequest(
+                        key = key,
+                        uploadId = uploadId,
+                        partNumber = part + 1
+                    )
                 )
-            )
-            val preSignedUrl = postVideoUrlResponse.preSignedUrl
-            val body = fileByteArray.toRequestBody(
-                contentType = videoBlock.mimeType.toMediaType(),
-                offset = partNumber,
-                byteCount = min(BYTE_OF_VIDEO_PART_SIZE, byteOfFileSize - partNumber)
-            )
-            val response = snapPointApi.putVideo(
-                url = preSignedUrl,
-                body = body
-            )
-            val eTag = response.headers()["ETag"] ?: throw Exception("서버 업로드 실패")
-            parts.add(Part(parts.size + 1, eTag.trim('"')))
+                val preSignedUrl = postVideoUrlResponse.preSignedUrl
+                val body = fileByteArray.toRequestBody(
+                    contentType = videoBlock.mimeType.toMediaType(),
+                    offset = partNumber,
+                    byteCount = min(BYTE_OF_VIDEO_PART_SIZE, byteOfFileSize - partNumber)
+                )
+                val response = snapPointApi.putVideo(
+                    url = preSignedUrl,
+                    body = body
+                )
+                val eTag = response.headers()["ETag"] ?: throw Exception("서버 업로드 실패")
+                parts.add(Part(part + 1, eTag.trim('"')))
+            }
+
+        }
+        while (parts.size != partNum) {
+            delay(10)
         }
 
         val videoEndResponse = snapPointApi.postVideoEnd(
@@ -155,14 +182,15 @@ class PostRepositoryImpl @Inject constructor(
                 key = key,
                 uploadId = uploadId,
                 mimeType = videoBlock.mimeType,
-                parts = parts
+                parts = parts.sortedBy { it.partNumber }
             )
         )
         return videoEndResponse.uuid
     }
 
     private suspend fun uploadImageAndGetUUid(imageBlock: PostBlockCreationState.IMAGE): String {
-        val requestBody = imageBlock.bitmap?.toByteArray()?.toRequestBody("image/webp".toMediaType())!!
+        val requestBody =
+            imageBlock.bitmap?.toByteArray()?.toRequestBody("image/webp".toMediaType())!!
         val multipartBody = MultipartBody.Part.createFormData("file", "image", requestBody)
         val uploadResult = snapPointApi.postImage(multipartBody)
         return uploadResult.uuid

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/BlockItemViewHolder.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/BlockItemViewHolder.kt
@@ -137,7 +137,7 @@ sealed class BlockItemViewHolder(
 
             }
 
-            val mediaItem = MediaItem.fromUri(block.uri?:block.content.toUri())
+            val mediaItem = MediaItem.fromUri(block.uri!!)
 
             binding.pv.player = ExoPlayer.Builder(itemView.context).build().also {
                 it.setMediaItem(mediaItem)

--- a/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostViewModel.kt
+++ b/android/app/src/main/java/com/boostcampwm2023/snappoint/presentation/createpost/CreatePostViewModel.kt
@@ -5,6 +5,7 @@ import android.graphics.BitmapFactory
 import android.location.Geocoder
 import android.net.Uri
 import android.util.Log
+import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.boostcampwm2023.snappoint.R
@@ -140,11 +141,12 @@ class CreatePostViewModel @Inject constructor(
             )
         }
     }
-    fun addVideoBlock(block: PostBlockState.VIDEO) {
+    private fun addVideoBlock(block: PostBlockState.VIDEO) {
         _uiState.update {
             it.copy(
                 postBlocks = it.postBlocks + PostBlockCreationState.VIDEO(
                     content = block.description,
+                    uri = block.content.toUri(),
                     uuid = block.uuid,
                     fileUuid = block.fileUuid,
                     description = block.description,


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): 화면 UI 그리기 -->

## 작업 개요

- [x] 게시글 수정에서 영상 플레이어 로딩
- [x] 영상 업로드 병렬 처리

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
게시글 수정에 들어갈 때 영상의 uri 값을 매칭시켜 영상을 로딩할 수 있도록 수정했습니다.
영상 데이터를 업로드 할 때, 파일을 작은 단위로 나누어 병렬로 업로드를 수행할 수 있도록 구현했습니다.

galaxy fold4 기준,
70mb -> 37mb

 37mb 영상에 대해
직렬 6.3초
병렬 5초

약 1.3초의 업로드 시간의 개선이 이루어졌습니다.

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->