### PR TITLE
Refactor: 게시글 요약 기능을 비동기 메시지 큐로 개선

### DIFF
--- a/backend/src/api/api.module.ts
+++ b/backend/src/api/api.module.ts
@@ -20,6 +20,7 @@ import { BlockModule } from '@/domain/block/block.module';
 import { HttpModule } from '@nestjs/axios';
 import { FileModule } from '@/domain/file/file.module';
 import { SummarizationService } from './summarization/summarization.service';
+import { SummarizationController } from './summarization/summarizationi.controller';
 
 @Module({
   imports: [
@@ -32,6 +33,24 @@ import { SummarizationService } from './summarization/summarization.service';
           options: {
             urls: [configService.getOrThrow<string>('RMQ_HOST')],
             queue: configService.getOrThrow<string>('RMQ_MEDIA_QUEUE'),
+            queueOptions: {
+              durable: true,
+            },
+          },
+        }),
+        inject: [ConfigService],
+      },
+    ]),
+
+    ClientsModule.registerAsync([
+      {
+        name: 'SUMMARY_SERVICE',
+        imports: [ConfigModule],
+        useFactory: async (configService: ConfigService) => ({
+          transport: Transport.RMQ,
+          options: {
+            urls: [configService.getOrThrow<string>('RMQ_HOST')],
+            queue: configService.getOrThrow<string>('RMQ_SUMMARY_QUEUE'),
             queueOptions: {
               durable: true,
             },
@@ -58,7 +77,7 @@ import { SummarizationService } from './summarization/summarization.service';
     HttpModule,
     FileModule,
   ],
-  controllers: [FileApiController, PostApiController, AuthController],
+  controllers: [FileApiController, PostApiController, AuthController, SummarizationController],
   providers: [
     FileApiService,
     PostApiService,

--- a/backend/src/api/post-api/post-api.controller.spec.ts
+++ b/backend/src/api/post-api/post-api.controller.spec.ts
@@ -16,6 +16,7 @@ import { RedisManager } from '@liaoliaots/nestjs-redis';
 import { ConfigService } from '@nestjs/config';
 import { UserService } from '@/domain/user/user.service';
 import { PRISMA_SERVICE, PrismaService } from '@/common/databases/prisma.service';
+import { ClientProxy } from '@nestjs/microservices';
 
 describe('PostApiController', () => {
   let controller: PostApiController;
@@ -42,6 +43,10 @@ describe('PostApiController', () => {
         {
           provide: PRISMA_SERVICE,
           useValue: mockDeep<PrismaService>(),
+        },
+        {
+          provide: 'SUMMARY_SERVICE',
+          useValue: mockDeep<ClientProxy>(),
         },
       ],
     })

--- a/backend/src/api/post-api/post-api.controller.spec.ts
+++ b/backend/src/api/post-api/post-api.controller.spec.ts
@@ -8,7 +8,6 @@ import { ValidationService } from '../validation/validation.service';
 import { TransformationService } from '../transformation/transformation.service';
 import { RedisCacheService } from '@/common/redis/redis-cache.service';
 import { mockDeep } from 'jest-mock-extended';
-import { SummarizationService } from '../summarization/summarization.service';
 import { BlockRepository } from '@/domain/block/block.repository';
 import { HttpService } from '@nestjs/axios';
 import { FileRepository } from '@/domain/file/file.repository';
@@ -34,7 +33,6 @@ describe('PostApiController', () => {
         TransformationService,
         RedisCacheService,
         RedisManager,
-        SummarizationService,
         BlockRepository,
         HttpService,
         FileRepository,

--- a/backend/src/api/post-api/post-api.service.spec.ts
+++ b/backend/src/api/post-api/post-api.service.spec.ts
@@ -11,7 +11,6 @@ import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Post } from '@prisma/client';
 import { TransformationService } from '../transformation/transformation.service';
 import { RedisCacheService } from '@/common/redis/redis-cache.service';
-import { SummarizationService } from '../summarization/summarization.service';
 import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
 import { UserService } from '@/domain/user/user.service';
@@ -33,7 +32,6 @@ describe('PostApiService', () => {
         BlockService,
         FileService,
         RedisCacheService,
-        SummarizationService,
         HttpService,
         ConfigService,
         UserService,

--- a/backend/src/api/post-api/post-api.service.spec.ts
+++ b/backend/src/api/post-api/post-api.service.spec.ts
@@ -1,3 +1,4 @@
+import { ClientProxy } from '@nestjs/microservices';
 import { ModifyPostDto } from './dtos/post/modify-post.dto';
 import { Test, TestingModule } from '@nestjs/testing';
 import { PostApiService } from './post-api.service';
@@ -39,6 +40,10 @@ describe('PostApiService', () => {
         {
           provide: PRISMA_SERVICE,
           useValue: mockDeep<PrismaService>(),
+        },
+        {
+          provide: 'SUMMARY_SERVICE',
+          useValue: mockDeep<ClientProxy>(),
         },
       ],
     })

--- a/backend/src/api/summarization/dtos/summary-post.dto.ts
+++ b/backend/src/api/summarization/dtos/summary-post.dto.ts
@@ -1,0 +1,5 @@
+export class SummaryPostDto {
+  post: { uuid: string; title: string };
+
+  blocks: { content: string; type: string }[];
+}

--- a/backend/src/api/summarization/summarization.service.ts
+++ b/backend/src/api/summarization/summarization.service.ts
@@ -1,6 +1,9 @@
+import { PostService } from './../../domain/post/post.service';
 import { HttpService } from '@nestjs/axios';
-import { Injectable, Logger } from '@nestjs/common';
+import { HttpException, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { firstValueFrom, map } from 'rxjs';
+import { SummaryPostDto } from './dtos/summary-post.dto';
 
 @Injectable()
 export class SummarizationService {
@@ -8,39 +11,68 @@ export class SummarizationService {
   private readonly maxContentLength = 1900;
   private readonly maxSentenceLength = 200;
   private readonly minWordCount = 5;
+  private readonly summaryClientId = this.configService.getOrThrow('NCP_AI_CLIENT_ID');
+  private readonly summaryClientSecret = this.configService.getOrThrow('NCP_AI_CLIENT_SECRET');
 
   constructor(
     private httpService: HttpService,
     private configService: ConfigService,
+    private postService: PostService,
   ) {}
 
-  async summarizeContent(title: string, content: string): Promise<string | null> {
-    try {
-      const response = await this.httpService
-        .post<{ summary: string }>(
-          this.summaryApiUrl,
-          {
-            document: { title, content },
-            option: { language: 'ko', model: 'general', tone: 3, summaryCount: 1 },
-          },
-          {
-            headers: this.getApiHeaders(),
-          },
-        )
-        .toPromise();
-
-      return response!.data.summary;
-    } catch (error) {
-      Logger.error(error.response?.data);
-      return null;
-    }
-  }
-
-  async summarizePost(title: string, blocks: { content: string; type: string }[]): Promise<string> {
+  async summarizePost({ post, blocks }: SummaryPostDto) {
+    const { uuid, title } = post;
     const content = this.prepareContent(blocks);
 
-    const summary: string | null = this.isContentValid(content) ? await this.summarizeContent(title, content) : null;
-    return summary ? summary : this.getFirstTextBlockContent(blocks);
+    // Summary AI의 동작 조건에 맞지 않는 경우, 첫 번째 텍스트 블록 내용을 저장한다.
+    if (!this.isContentValid(content)) {
+      return this.postService.updatePost({
+        where: { uuid },
+        data: { summary: this.getFirstTextBlockContent(blocks) },
+      });
+    }
+
+    const summary$ = this.summarizeContent(title, content);
+
+    // 요약이 되지 않을 경우 (NULL) 첫 번째 텍스트 블록 내용을 저장한다.
+    if (summary$ === null) {
+      return this.postService.updatePost({
+        where: { uuid },
+        data: { summary: this.getFirstTextBlockContent(blocks) },
+      });
+    }
+
+    const { summary } = await firstValueFrom(summary$);
+    return this.postService.updatePost({
+      where: { uuid },
+      data: { summary },
+    });
+  }
+
+  private summarizeContent(title: string, content: string) {
+    const data = {
+      document: { title, content },
+      option: { language: 'ko', model: 'general', tone: 3, summaryCount: 1 },
+    };
+
+    const config = {
+      headers: {
+        'X-NCP-APIGW-API-KEY-ID': this.summaryClientId,
+        'X-NCP-APIGW-API-KEY': this.summaryClientSecret,
+      },
+    };
+
+    try {
+      const summary$ = this.httpService
+        .post<{ summary: string }>(this.summaryApiUrl, data, config)
+        .pipe(map((res) => res.data));
+
+      return summary$;
+    } catch (error) {
+      // API 연결 오류일 경우 NULL을 반환한다.
+      if (error instanceof HttpException) return null;
+      throw error;
+    }
   }
 
   private prepareContent(blocks: { content: string; type: string }[]): string {
@@ -66,12 +98,5 @@ export class SummarizationService {
   private getFirstTextBlockContent(blocks: { content: string; type: string }[]): string {
     const textBlock = blocks.find((block) => block.type === 'text');
     return textBlock ? textBlock.content : blocks[0].content;
-  }
-
-  private getApiHeaders() {
-    return {
-      'X-NCP-APIGW-API-KEY-ID': this.configService.getOrThrow('NCP_AI_CLIENT_ID'),
-      'X-NCP-APIGW-API-KEY': this.configService.getOrThrow('NCP_AI_CLIENT_SECRET'),
-    };
   }
 }

--- a/backend/src/api/summarization/summarizationi.controller.ts
+++ b/backend/src/api/summarization/summarizationi.controller.ts
@@ -1,0 +1,21 @@
+import { SummarizationService } from '@/api/summarization/summarization.service';
+import { Controller } from '@nestjs/common';
+
+import { Ctx, MessagePattern, Payload, RmqContext } from '@nestjs/microservices';
+import { SummaryPostDto } from './dtos/summary-post.dto';
+
+@Controller('summary')
+export class SummarizationController {
+  constructor(private readonly summarizationService: SummarizationService) {}
+
+  @MessagePattern({ cmd: 'summary.post' })
+  async summarizePost(@Payload() dto: SummaryPostDto, @Ctx() context: RmqContext) {
+    const channel = context.getChannelRef();
+    const originalMsg = context.getMessage();
+
+    this.summarizationService
+      .summarizePost(dto)
+      .then(() => channel.ack(originalMsg))
+      .catch(() => channel.reject(originalMsg));
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -31,6 +31,16 @@ async function bootstrap() {
     },
   });
 
+  app.connectMicroservice<MicroserviceOptions>({
+    transport: Transport.RMQ,
+    options: {
+      urls: [configService.getOrThrow<string>('RMQ_HOST')],
+      queue: configService.getOrThrow<string>('RMQ_SUMMARY_QUEUE'),
+      noAck: false,
+      queueOptions: { durable: true },
+    },
+  });
+
   await app.startAllMicroservices();
   await app.listen(3000);
 }


### PR DESCRIPTION
## 작업 개요
게시글 내용을 NCP의 API를 호출해 요약해 약 500ms의 응답 시간이 발생하였다. (Postman 기준) 이를 비동기 메시지 큐 방식으로 최적화하였다.

## 작업 사항
- [x] `SummaryService` 리팩토링
    - [x] HTTP 요청을 Promise를 Observable로 변환하였음
- [x] 게시글 요약 요청을 비동기 메시지 큐로 변경
    - [x] `Summary Queue`를 생성한 후 연결하기
    - [x] 게시글 생성 완료 시 `emit` 수행

## 고민한 점들
### 비동기 메시지 큐를 추가로 사용한 이유?
- NCP의 API를 사용한다는 점에서, 너무 잦은 API 호출, 지연된 작업으로 메시지 소실이 염려되었음
- 그러므로 [API 명세](https://api.ncloud-docs.com/docs/ai-naver-clovasummary-api)를 참고해, 회복 불가능한 오류인 경우 다시 수행하도록 구현
- 회복 가능한 오류는 `Promise`의 예외 처리에 따라, 다시 메시지를 `requeue` 하였음

## 스크린샷(필수 X)