### PR TITLE
Feature: 게시글 생성, 수정 시 검증 로직 추가

### DIFF
--- a/backend/src/api/api.module.ts
+++ b/backend/src/api/api.module.ts
@@ -21,6 +21,7 @@ import { HttpModule } from '@nestjs/axios';
 import { FileModule } from '@/domain/file/file.module';
 import { SummarizationService } from './summarization/summarization.service';
 import { SummarizationController } from './summarization/summarizationi.controller';
+import { UtilityModule } from '@/common/utility/utility.module';
 
 @Module({
   imports: [
@@ -76,6 +77,7 @@ import { SummarizationController } from './summarization/summarizationi.controll
     BlockModule,
     HttpModule,
     FileModule,
+    UtilityModule,
   ],
   controllers: [FileApiController, PostApiController, AuthController, SummarizationController],
   providers: [

--- a/backend/src/api/post-api/post-api.service.ts
+++ b/backend/src/api/post-api/post-api.service.ts
@@ -1,10 +1,4 @@
-import {
-  ForbiddenException,
-  Inject,
-  Injectable,
-  InternalServerErrorException,
-  NotFoundException,
-} from '@nestjs/common';
+import { Inject, Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { PostService } from '@/domain/post/post.service';
 import { BlockService } from '@/domain/block/block.service';
 import { FileService } from '@/domain/file/file.service';
@@ -24,6 +18,7 @@ import { WritePostDto } from './dtos/post/write-post.dto';
 import { ModifyPostDto } from './dtos/post/modify-post.dto';
 import { ClientProxy } from '@nestjs/microservices';
 import { SummaryPostDto } from '../summarization/dtos/summary-post.dto';
+import { UtilityService } from '@/common/utility/utility.service';
 
 @Injectable()
 export class PostApiService {
@@ -36,6 +31,7 @@ export class PostApiService {
     private readonly redisService: RedisCacheService,
     @Inject('SUMMARY_SERVICE') private readonly summaryService: ClientProxy,
     private readonly userService: UserService,
+    private readonly utils: UtilityService,
   ) {}
 
   private assemblePost(post: Post, user: User, blocks: Block[], files: File[]): PostDto {
@@ -49,13 +45,13 @@ export class PostApiService {
   }
 
   private createBlockDtoMap(files: File[], blocks: Block[]) {
-    const fileDtoMap = this.transform.toMapFromArray<File, string, FileDto>(
+    const fileDtoMap = this.utils.toTransMapFromArray<File, string, FileDto>(
       files,
       (file: File) => file.sourceUuid!,
       (file: File) => FileDto.of(file),
     );
 
-    const blockDtoMap = this.transform.toMapFromArray<Block, string, BlockDto>(
+    const blockDtoMap = this.utils.toTransMapFromArray<Block, string, BlockDto>(
       blocks,
       (block: Block) => block.postUuid,
       (block: Block) => BlockDto.of(block, fileDtoMap.get(block.uuid)),
@@ -236,11 +232,13 @@ export class PostApiService {
     const decomposedPostDto = this.transform.decomposePostData(postDto, uuid);
     const { post, blocks, files } = decomposedPostDto;
 
-    const existPost = await this.accessPost(uuid, userUuid);
-    const user = await this.userService.findUserByUniqueInput({ uuid: existPost.userUuid });
+    const [user] = await Promise.all([
+      this.userService.findUserByUniqueInput({ uuid: userUuid }),
+      this.validation.validatePost({ uuid, userUuid }),
+    ]);
 
     if (!user) {
-      throw new NotFoundException(`Cloud not found User with UUID: ${existPost.userUuid}`);
+      throw new NotFoundException(`Cloud not found User with UUID: ${userUuid}`);
     }
 
     const [updatedBlocks, updatedFiles] = await Promise.all([
@@ -264,15 +262,13 @@ export class PostApiService {
 
   @Transactional()
   async deletePost(uuid: string, userUuid: string) {
-    const existPost = await this.accessPost(uuid, userUuid);
-
-    const [deletedPost, user] = await Promise.all([
-      this.postService.deletePost({ uuid }),
+    const [user] = await Promise.all([
       this.userService.findUserByUniqueInput({ uuid: userUuid }),
+      this.validation.validatePost({ uuid, userUuid }),
     ]);
 
     if (!user) {
-      throw new NotFoundException(`Cloud not found User with UUID: ${existPost.userUuid}`);
+      throw new NotFoundException(`Cloud not found User with UUID: ${userUuid}`);
     }
 
     const blocks = await this.blockService.deleteBlocksByPost(existPost.uuid);
@@ -283,17 +279,5 @@ export class PostApiService {
 
     return this.assemblePost(deletedPost, user, blocks, files);
   }
-
-  private async accessPost(uuid: string, userUuid: string) {
-    const existPost = await this.postService.findPost({ uuid });
-
-    if (!existPost) {
-      throw new NotFoundException(`Cloud not found post with UUID: ${uuid}`);
-    }
-
-    if (existPost.userUuid !== userUuid) {
-      throw new ForbiddenException('Could not access this post. please check your permission.');
-    }
-    return existPost;
   }
 }

--- a/backend/src/api/transformation/transformation.service.ts
+++ b/backend/src/api/transformation/transformation.service.ts
@@ -31,17 +31,6 @@ export class TransformationService {
     };
   }
 
-  toMapFromArray<T, K, V>(items: T[], extractKeyFn: (item: T) => K, transformFn: (item: T) => V): Map<K, V[]> {
-    const map = new Map<K, V[]>();
-    items.forEach((item) => {
-      const key = extractKeyFn(item);
-      const collection = map.get(key) || [];
-      collection.push(transformFn(item));
-      map.set(key, collection);
-    });
-    return map;
-  }
-
   /**
    * 게시글 파일의 썸네일 유무에 따라 분할해 반환한다.
    * @param files 게시글의 파일 데이터들

--- a/backend/src/api/validation/dtos/validate-block.dto.ts
+++ b/backend/src/api/validation/dtos/validate-block.dto.ts
@@ -3,6 +3,8 @@ export class ValidateBlockDto {
 
   type: string;
 
+  postUuid: string;
+
   latitude?: number;
 
   longitude?: number;

--- a/backend/src/api/validation/dtos/validate-post.dto.ts
+++ b/backend/src/api/validation/dtos/validate-post.dto.ts
@@ -1,0 +1,5 @@
+export class ValidatePostDto {
+  uuid: string;
+
+  userUuid: string;
+}

--- a/backend/src/api/validation/validation.service.ts
+++ b/backend/src/api/validation/validation.service.ts
@@ -1,31 +1,27 @@
+import { PostService } from '@/domain/post/post.service';
 import { FileService } from '@/domain/file/file.service';
-import { BadRequestException, ConflictException, ForbiddenException, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { ValidateFileDto } from '@/api/validation/dtos/validate-file.dto';
 import { ValidateBlockDto } from '@/api/validation/dtos/validate-block.dto';
-import { AttachFileDto } from '../post-api/dtos/file/attach-file.dto';
 import { FindNearbyPostDto } from '../post-api/dtos/find-nearby-post.dto';
+import { ValidatePostDto } from './dtos/validate-post.dto';
+import { UtilityService } from '@/common/utility/utility.service';
+import { BlockService } from '@/domain/block/block.service';
+import { Block } from '@prisma/client';
 
 @Injectable()
 export class ValidationService {
-  constructor(private readonly fileService: FileService) {}
-
-  /**
-   * 두 지점의 거리를 계산하고, KM 단위로 반환한다.
-   * @param latMin 위도의 최솟값
-   * @param lonMin 경도의 최솟값
-   * @param latMax 위도의 최댓값
-   * @param lonMax 경도의 최댓값
-   * @returns 두 지점의 거리 (KM 단위)
-   */
-  private calDistance(latMin: number, lonMin: number, latMax: number, lonMax: number) {
-    const R = 6371000; // 지구 반지름 (미터 단위)
-    const rad = Math.PI / 180; // 도를 라디안으로 변환
-
-    const x = (lonMax * rad - lonMin * rad) * Math.cos((latMin * rad + latMax * rad) / 2);
-    const y = latMax * rad - latMin * rad;
-
-    return (Math.sqrt(x * x + y * y) * R) / 1000;
-  }
+  constructor(
+    private readonly postService: PostService,
+    private readonly fileService: FileService,
+    private readonly utils: UtilityService,
+  ) {}
 
   /**
    * 조회할 영역이 적합한 영역인지 검사해 반환한다.
@@ -34,7 +30,7 @@ export class ValidationService {
   validateLookupArea(dto: FindNearbyPostDto) {
     const { latitudeMin, latitudeMax, longitudeMin, longitudeMax } = dto;
 
-    const dist = this.calDistance(latitudeMin, longitudeMin, latitudeMax, longitudeMax);
+    const dist = this.utils.calDistance(latitudeMin, longitudeMin, latitudeMax, longitudeMax);
 
     if (dist > 20.0) {
       throw new BadRequestException(`The lookup areas is too large`);
@@ -101,5 +97,41 @@ export class ValidationService {
         throw new BadRequestException('Media Block must have at least one files');
       }
     });
+  }
+
+  async validatePost(dto: ValidatePostDto) {
+    const { uuid, userUuid } = dto;
+
+    const post = await this.postService.findPost({ uuid });
+
+    if (!post) {
+      throw new NotFoundException(`Cloud not found post with UUID: ${uuid}`);
+    }
+
+    if (post.userUuid !== userUuid) {
+      throw new ForbiddenException('Could not access this post. please check your permission.');
+    }
+
+    return post;
+  }
+
+  private validateBlock(blockDto: ValidateBlockDto, sourceFiles?: ValidateFileDto[]) {
+    const { type, latitude, longitude } = blockDto;
+
+    if (type === 'text' && (latitude !== undefined || longitude !== undefined)) {
+      throw new BadRequestException('Latitude and longitude should not be provided for text type');
+    }
+
+    if (type === 'media' && (latitude === undefined || longitude === undefined)) {
+      throw new BadRequestException('Latitude and longitude should be provided for media type');
+    }
+
+    if (type === 'text' && sourceFiles) {
+      throw new BadRequestException('File block must not have media file');
+    }
+
+    if (type === 'media' && (!sourceFiles || sourceFiles.length === 0)) {
+      throw new BadRequestException('Media Block must have at least one files');
+    }
   }
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -16,6 +16,7 @@ import { RedisCacheModule } from './common/redis/redis-cache.module';
 import { HealthModule } from './common/health/health.module';
 import { TransactionModule, txExtension } from '@takeny1998/nestjs-prisma-transactional';
 import { PRISMA_SERVICE, PrismaService } from './common/databases/prisma.service';
+import { UtilityModule } from './common/utility/utility.module';
 
 @Global()
 @Module({
@@ -45,8 +46,8 @@ import { PRISMA_SERVICE, PrismaService } from './common/databases/prisma.service
     ApiModule,
     RedisCacheModule,
     HealthModule,
+    UtilityModule,
   ],
-  controllers: [],
   providers: [
     RefreshTokenService,
     {

--- a/backend/src/common/utility/utility.module.ts
+++ b/backend/src/common/utility/utility.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { UtilityService } from './utility.service';
+
+@Module({
+  providers: [UtilityService],
+  exports: [UtilityService],
+})
+export class UtilityModule {}

--- a/backend/src/common/utility/utility.service.spec.ts
+++ b/backend/src/common/utility/utility.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UtilityService } from './utility.service';
+
+describe('UtilityService', () => {
+  let service: UtilityService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [UtilityService],
+    }).compile();
+
+    service = module.get<UtilityService>(UtilityService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/common/utility/utility.service.ts
+++ b/backend/src/common/utility/utility.service.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class UtilityService {
+  constructor() {}
+
+  /**
+   * 두 지점의 거리를 계산하고, KM 단위로 반환한다.
+   * @param latMin 위도의 최솟값
+   * @param lonMin 경도의 최솟값
+   * @param latMax 위도의 최댓값
+   * @param lonMax 경도의 최댓값
+   * @returns 두 지점의 거리 (KM 단위)
+   */
+  calDistance(latMin: number, lonMin: number, latMax: number, lonMax: number) {
+    const R = 6371000; // 지구 반지름 (미터 단위)
+    const rad = Math.PI / 180; // 도를 라디안으로 변환
+
+    const x = (lonMax * rad - lonMin * rad) * Math.cos((latMin * rad + latMax * rad) / 2);
+    const y = latMax * rad - latMin * rad;
+
+    return (Math.sqrt(x * x + y * y) * R) / 1000;
+  }
+
+  toMapFromArray<K, V>(items: V[], extractKeyFn: (item: V) => K): Map<K, V[]> {
+    const map = new Map<K, V[]>();
+    items.forEach((item) => {
+      const key = extractKeyFn(item);
+      const collection = map.get(key) || [];
+      collection.push(item);
+      map.set(key, collection);
+    });
+    return map;
+  }
+
+  toUniqueMapFromArray<K, V>(items: V[], extractKeyFn: (item: V) => K): Map<K, V> {
+    const map = new Map<K, V>();
+    items.forEach((item) => {
+      const key = extractKeyFn(item);
+      map.set(key, item);
+    });
+    return map;
+  }
+
+  toTransMapFromArray<T, K, V>(items: T[], extractKeyFn: (item: T) => K, transformFn: (item: T) => V): Map<K, V[]> {
+    const map = new Map<K, V[]>();
+    items.forEach((item) => {
+      const key = extractKeyFn(item);
+      const collection = map.get(key) || [];
+      collection.push(transformFn(item));
+      map.set(key, collection);
+    });
+    return map;
+  }
+}

--- a/backend/src/domain/block/block.service.ts
+++ b/backend/src/domain/block/block.service.ts
@@ -5,6 +5,7 @@ import { BlockRepository } from '@/domain/block/block.repository';
 import { FindBlocksByAreaDto } from '@/domain/block/dtos/find-blocks-by-area.dto';
 import { FindBlocksByPostDto } from '@/domain/block/dtos/find-blocks-by-post.dto';
 import { Block } from '@prisma/client';
+import { FindBlocksDto } from './dtos/find-blocks.dto';
 
 @Injectable()
 export class BlockService {
@@ -17,6 +18,10 @@ export class BlockService {
 
   async findBlocksByArea(dto: FindBlocksByAreaDto): Promise<Block[]> {
     return this.repository.findManyByArea(dto);
+  }
+
+  async findBlocksByIdList(dto: FindBlocksDto[]): Promise<Block[]> {
+    return this.repository.findMany({ where: { OR: dto } });
   }
 
   async findBlocksByPost(dto: FindBlocksByPostDto): Promise<Block[]> {

--- a/backend/src/domain/block/dtos/find-blocks.dto.ts
+++ b/backend/src/domain/block/dtos/find-blocks.dto.ts
@@ -1,0 +1,3 @@
+export class FindBlocksDto {
+  uuid: string;
+}


### PR DESCRIPTION
## 작업 개요
PostApiService에서 `accessPost` 처럼 게시글 검증하는 메소드가 있고, 블록의 경우 수정하는 경우에 추가로 "다른 게시글 블록에 접근" 및 "타입을 변경"하는지 검증하였음

## 작업 사항
- [x] 게시글 수정 시 검증 로직을 추가하고, 메소드로 분리
- [x] PostAPIService의 검증 로직을 ValidationService로 분리
- [x] 도메인에 관련되지 않는 기능은 공통 UtilityModule로 분리